### PR TITLE
Xcode 9.3

### DIFF
--- a/Callisto.xcodeproj/project.pbxproj
+++ b/Callisto.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		CD4901232008EFB6000F5F08 /* SlackCommunicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE01EE009C600E8EE2E /* SlackCommunicationController.swift */; };
 		CD512D8E2008C1F9002EB718 /* ios_build_4822.log in Resources */ = {isa = PBXBuildFile; fileRef = CD512D8D2008C1F9002EB718 /* ios_build_4822.log */; };
 		CD512D902008C257002EB718 /* GithubCommunicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD512D8F2008C257002EB718 /* GithubCommunicationTests.swift */; };
-		CD512D942008C374002EB718 /* githubSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = CD512D932008C374002EB718 /* githubSettings.plist */; };
 		CD512D952008C5A1002EB718 /* GitHubCommunicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDDA1EE009C600E8EE2E /* GitHubCommunicationController.swift */; };
 		CD512D962008C5C5002EB718 /* GithubAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDD91EE009C600E8EE2E /* GithubAccount.swift */; };
 		CD512D972008C5D7002EB718 /* URLSession+synchronousTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE31EE009C600E8EE2E /* URLSession+synchronousTask.swift */; };
@@ -47,6 +46,10 @@
 		CD8BBDF11EE009C600E8EE2E /* SlackField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE11EE009C600E8EE2E /* SlackField.swift */; };
 		CD8BBDF21EE009C600E8EE2E /* SlackMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE21EE009C600E8EE2E /* SlackMessage.swift */; };
 		CD8BBDF31EE009C600E8EE2E /* URLSession+synchronousTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE31EE009C600E8EE2E /* URLSession+synchronousTask.swift */; };
+		CDF007082074FAC200257FCC /* mac_build_8731.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF007062074FAC200257FCC /* mac_build_8731.log */; };
+		CDF007092074FAC200257FCC /* ios_build_8731.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF007072074FAC200257FCC /* ios_build_8731.log */; };
+		CDF0070E20760B1900257FCC /* ios_build_8745.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF0070C20760B1900257FCC /* ios_build_8745.log */; };
+		CDF0070F20760B1900257FCC /* mac_build_8745.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF0070D20760B1900257FCC /* mac_build_8745.log */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -69,7 +72,6 @@
 		CD49011F2008EF5E000F5F08 /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		CD512D8D2008C1F9002EB718 /* ios_build_4822.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_4822.log; sourceTree = "<group>"; };
 		CD512D8F2008C257002EB718 /* GithubCommunicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubCommunicationTests.swift; sourceTree = "<group>"; };
-		CD512D932008C374002EB718 /* githubSettings.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = githubSettings.plist; sourceTree = "<group>"; };
 		CD8320FE1EE7DF640029DBE0 /* CallistoTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CallistoTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD8321001EE7DF640029DBE0 /* ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTest.swift; sourceTree = "<group>"; };
 		CD8321021EE7DF640029DBE0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -90,6 +92,10 @@
 		CD8BBDE11EE009C600E8EE2E /* SlackField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlackField.swift; sourceTree = "<group>"; };
 		CD8BBDE21EE009C600E8EE2E /* SlackMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlackMessage.swift; sourceTree = "<group>"; };
 		CD8BBDE31EE009C600E8EE2E /* URLSession+synchronousTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLSession+synchronousTask.swift"; sourceTree = "<group>"; };
+		CDF007062074FAC200257FCC /* mac_build_8731.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mac_build_8731.log; sourceTree = "<group>"; };
+		CDF007072074FAC200257FCC /* ios_build_8731.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_8731.log; sourceTree = "<group>"; };
+		CDF0070C20760B1900257FCC /* ios_build_8745.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_8745.log; sourceTree = "<group>"; };
+		CDF0070D20760B1900257FCC /* mac_build_8745.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mac_build_8745.log; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,18 +116,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		CD7691761F1CB29C00E4DC16 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
 		CD8320FF1EE7DF640029DBE0 /* CallistoTest */ = {
 			isa = PBXGroup;
 			children = (
 				CD8321001EE7DF640029DBE0 /* ParserTest.swift */,
-				CD512D932008C374002EB718 /* githubSettings.plist */,
 				CD512D8F2008C257002EB718 /* GithubCommunicationTests.swift */,
 				CD4901172008EEC6000F5F08 /* SlackCommunicationTests.swift */,
 				CD8321091EE7DFBF0029DBE0 /* Resources */,
@@ -141,6 +139,10 @@
 		CD83210A1EE7DFC40029DBE0 /* Sample Logs */ = {
 			isa = PBXGroup;
 			children = (
+				CDF0070C20760B1900257FCC /* ios_build_8745.log */,
+				CDF0070D20760B1900257FCC /* mac_build_8745.log */,
+				CDF007072074FAC200257FCC /* ios_build_8731.log */,
+				CDF007062074FAC200257FCC /* mac_build_8731.log */,
 				CD081CBD1EE7F1D700F537B3 /* mac_build_4454.log */,
 				CD081CBB1EE7F19100F537B3 /* ios_build_4454.log */,
 				CD512D8D2008C1F9002EB718 /* ios_build_4822.log */,
@@ -174,7 +176,6 @@
 				CD8BBDFA1EE00A8E00E8EE2E /* Parser */,
 				CD8BBDF41EE00A2500E8EE2E /* Communication Controller */,
 				CD8BBDF91EE00A7B00E8EE2E /* Helper */,
-				CD7691761F1CB29C00E4DC16 /* Supporting Files */,
 				CD49011F2008EF5E000F5F08 /* Common.swift */,
 			);
 			path = Callisto;
@@ -331,9 +332,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDF007082074FAC200257FCC /* mac_build_8731.log in Resources */,
+				CDF007092074FAC200257FCC /* ios_build_8731.log in Resources */,
 				CD512D8E2008C1F9002EB718 /* ios_build_4822.log in Resources */,
+				CDF0070F20760B1900257FCC /* mac_build_8745.log in Resources */,
+				CDF0070E20760B1900257FCC /* ios_build_8745.log in Resources */,
 				CD081CBE1EE7F1D700F537B3 /* mac_build_4454.log in Resources */,
-				CD512D942008C374002EB718 /* githubSettings.plist in Resources */,
 				CD081CBC1EE7F19100F537B3 /* ios_build_4454.log in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Callisto/MainController.swift
+++ b/Callisto/MainController.swift
@@ -78,7 +78,6 @@ class MainController {
         }
 
         warningCount += self.parser.buildErrorMessages.count
-        warningCount += self.parser.staticAnalyzerMessages.count
         warningCount += self.parser.unitTestMessages.count
 
         return .success(warningCount: Int32(warningCount))

--- a/Callisto/MainController.swift
+++ b/Callisto/MainController.swift
@@ -71,7 +71,7 @@ class MainController {
             LogError("\(self.parser.buildErrorMessages.count). Build Errors")
         }
         if self.parser.staticAnalyzerMessages.isEmpty == false {
-            LogError("\(self.parser.staticAnalyzerMessages.count). Static Analyzer Warnings")
+            LogWarning("\(self.parser.staticAnalyzerMessages.count). Static Analyzer Warnings")
         }
         if self.parser.unitTestMessages.isEmpty == false {
             LogError("\(self.parser.unitTestMessages.count). Unit Test Errors")

--- a/CallistoTest/ParserTest.swift
+++ b/CallistoTest/ParserTest.swift
@@ -60,4 +60,38 @@ class CallistoTest: XCTestCase {
         print(parser.staticAnalyzerMessages)
         print(parser.unitTestMessages)
     }
+
+    func testXcode9_3_MobileParser() {
+        guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "ios_build_8745", withExtension: "log") else { XCTFail(); return; }
+        guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
+
+        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+
+        if case .success(let code) = parser.parse() {
+            XCTAssertEqual(code, 65)
+        } else {
+            XCTFail()
+        }
+
+        XCTAssertEqual(parser.buildErrorMessages.count, 1)
+        XCTAssertEqual(parser.staticAnalyzerMessages.count, 10)
+        XCTAssertEqual(parser.unitTestMessages.count, 0)
+    }
+
+    func testXcode9_3_DesktopParser() {
+        guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "mac_build_8745", withExtension: "log") else { XCTFail(); return; }
+        guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
+
+        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+
+        if case .success(let code) = parser.parse() {
+            XCTAssertEqual(code, -1)
+        } else {
+            XCTFail()
+        }
+
+        XCTAssertEqual(parser.buildErrorMessages.count, 0)
+        XCTAssertEqual(parser.staticAnalyzerMessages.count, 6)
+        XCTAssertEqual(parser.unitTestMessages.count, 0)
+    }
 }

--- a/CallistoTest/ios_build_8731.log
+++ b/CallistoTest/ios_build_8731.log
@@ -1,0 +1,3703 @@
+~~~ Preparing build folder
+[90m$[0m mkdir -p "/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app"
+[90m$[0m cd "/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app"
+[90m$[0m ssh-keyscan "github.com" >> "/Users/administrator/.ssh/known_hosts"
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+[90m$[0m git remote set-url origin "git@github.com:company/app.git"
+[90m$[0m git clean "-fdq"
+[90m$[0m git submodule foreach --recursive git clean "-fdq"
+[90m$[0m git fetch -v origin "refs/pull/3069/head"
+From github.com:company/app
+ * branch                  refs/pull/3069/head -> FETCH_HEAD
+[90m$[0m git checkout -f "42839f3ce91a4f3a339286827ac6f16affca3f47"
+HEAD is now at 42839f3ce9... Update layout when rewiring
+[90m$[0m git submodule sync --recursive
+[90m$[0m git submodule update --init --recursive
+[90m$[0m git submodule foreach --recursive git reset --hard
+~~~ Running command
+[90m$[0m #!/bin/bash
+
+if [ "$(ls .scripts/buildkite | grep ios_tests.sh)" ]
+then ./.scripts/buildkite/ios_tests.sh
+else
+echo "----------------------------------"
+echo "##  BuildkiteScript not found   ##"
+echo "##    fallback to old style     ##"
+echo "----------------------------------"
+bundle install --path ~/gems
+bundle exec fastlane ios test
+fi
+Using rake 12.3.0
+Using CFPropertyList 2.3.6
+Using concurrent-ruby 1.0.5
+Using i18n 0.9.3
+Using minitest 5.11.2
+Using thread_safe 0.3.6
+Using tzinfo 1.2.4
+Using activesupport 4.2.10
+Using public_suffix 2.0.5
+Using addressable 2.5.2
+Using babosa 1.0.2
+Using bundler 1.16.0
+Using claide 1.0.2
+Using colored2 3.1.2
+Using cork 0.3.0
+Using nap 1.1.0
+Using open4 1.3.4
+Using claide-plugins 0.9.2
+Using fuzzy_match 2.0.4
+Using cocoapods-core 1.3.1
+Using cocoapods-deintegrate 1.0.2
+Using cocoapods-downloader 1.1.3
+Using cocoapods-plugins 1.0.0
+Using cocoapods-search 1.0.0
+Using cocoapods-stats 1.0.0
+Using netrc 0.11.0
+Using cocoapods-trunk 1.3.0
+Using cocoapods-try 1.1.0
+Using escape 0.0.4
+Using fourflusher 2.0.1
+Using gh_inspector 1.0.3
+Using molinillo 0.5.7
+Using ruby-macho 1.1.0
+Using nanaimo 0.2.3
+Using xcodeproj 1.5.4
+Using cocoapods 1.3.1
+Using redcarpet 3.4.0
+Using cocoapods-acknowledgements 1.1.2
+Using colored 1.2
+Using highline 1.7.10
+Using commander-fastlane 4.4.5
+Using multipart-post 2.0.0
+Using faraday 0.14.0
+Using faraday-http-cache 1.3.1
+Using git 1.3.0
+Using kramdown 1.16.2
+Using no_proxy_fix 0.1.2
+Using sawyer 0.8.1
+Using octokit 4.8.0
+Using unicode-display_width 1.3.0
+Using terminal-table 1.8.0
+Using danger 5.5.7
+Using thor 0.20.0
+Using danger-swiftlint 0.12.1
+Using declarative 0.0.10
+Using declarative-option 0.1.0
+Using unf_ext 0.0.7.4
+Using unf 0.1.4
+Using domain_name 0.5.20170404
+Using dotenv 2.2.1
+Using excon 0.60.0
+Using http-cookie 1.0.3
+Using faraday-cookie_jar 0.0.6
+Using faraday_middleware 0.12.2
+Using fastimage 2.1.1
+Using jwt 2.1.0
+Using little-plugger 1.1.4
+Using multi_json 1.13.1
+Using logging 2.2.2
+Using memoist 0.16.0
+Using os 0.9.6
+Using signet 0.8.1
+Using googleauth 0.6.2
+Using httpclient 2.8.3
+Using mime-types-data 3.2016.0521
+Using mime-types 3.1
+Using uber 0.1.0
+Using representable 3.0.4
+Using retriable 3.1.1
+Using google-api-client 0.13.6
+Using json 2.1.0
+Using mini_magick 4.5.1
+Using multi_xml 0.6.0
+Using plist 3.4.0
+Using rubyzip 1.2.1
+Using security 0.1.3
+Using slack-notifier 2.3.2
+Using terminal-notifier 1.8.0
+Using tty-screen 0.6.4
+Using tty-cursor 0.5.0
+Using tty-spinner 0.8.0
+Using word_wrap 1.0.0
+Using rouge 2.0.7
+Using xcpretty 0.2.8
+Using xcpretty-travis-formatter 1.0.0
+Using fastlane 2.79.0
+[32mBundle complete! 6 Gemfile dependencies, 96 gems now installed.[0m
+[32mBundled gems are installed into `/Users/administrator/gems`[0m
+[17:26:10]: [32m----------------------------------------[0m
+[17:26:10]: [32m--- Step: Verifying fastlane version ---[0m
+[17:26:10]: [32m----------------------------------------[0m
+[17:26:10]: Your fastlane version 2.79.0 matches the minimum requirement of 1.37.0  ✅
+[17:26:10]: [33mName of the lane 'build_app' is already taken by the action named 'build_app'[0m
+[17:26:10]: [32mDriving the lane 'ios staticAnalyze' 🚀[0m
+[17:26:10]: [32m--------------------------------[0m
+[17:26:10]: [32m--- Step: clear_derived_data ---[0m
+[17:26:10]: [32m--------------------------------[0m
+[17:26:10]: Derived Data path located at: /Users/administrator/Library/Developer/Xcode/DerivedData
+[17:26:13]: [32mSuccessfully cleared Derived Data ♻️[0m
+[17:26:13]: [32m------------------[0m
+[17:26:13]: [32m--- Step: scan ---[0m
+[17:26:13]: [32m------------------[0m
+[17:26:13]: [36m$ xcodebuild -list -workspace app.xcworkspace[0m
+[17:26:15]: [36m$ xcodebuild -showBuildSettings -workspace app.xcworkspace -scheme app\ for\ iOS[0m
+[17:26:18]: [36m$ xcodebuild -list -workspace app.xcworkspace[0m
+[17:26:20]: [36m$ xcodebuild -showBuildSettings -workspace app.xcworkspace -scheme app\ for\ iOS[0m
+
++------------------------+-------------------------------------------------------------------------------------------------------------+
+|                                                       [32mSummary for scan 2.79.0[0m                                                        |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+| devices                | ["iPhone 6s"]                                                                                               |
+| clean                  | true                                                                                                        |
+| workspace              | app.xcworkspace                                                                                        |
+| scheme                 | app for iOS                                                                                            |
+| xcargs                 | CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze |
+| derived_data_path      | /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq              |
+| skip_build             | false                                                                                                       |
+| output_directory       | ./fastlane/test_output                                                                                      |
+| output_types           | html,junit                                                                                                  |
+| buildlog_path          | ~/Library/Logs/scan                                                                                         |
+| include_simulator_logs | false                                                                                                       |
+| open_report            | false                                                                                                       |
+| skip_slack             | false                                                                                                       |
+| slack_only_on_failure  | false                                                                                                       |
+| use_clang_report_name  | false                                                                                                       |
+| fail_build             | true                                                                                                        |
+| xcode_path             | /Applications/Xcode.app                                                                                     |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+
+[17:26:24]: [36m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace app.xcworkspace -scheme app\ for\ iOS -destination 'platform=iOS Simulator,id=C5E91E1A-FF7B-4D7A-81C1-C48707444457' -derivedDataPath '/Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq' CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze clean build test | tee '/Users/administrator/Library/Logs/scan/app-app for iOS.log' | xcpretty  --report html --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/fastlane/test_output/report.html' --report junit --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/fastlane/test_output/report.junit' --report junit --output '/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/junit_report20180403-53129-y1o2kv'[0m
+[17:26:24]: ▸ [35mLoading...[0m
+[17:26:28]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared watchOS [Debug][0m
+[17:26:28]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:28]: [35m[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist[0m
+[17:26:28]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[17:26:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[17:26:39]: [35m[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c[0m
+[17:26:39]: [35m[33m▸[0m [39;1mLinking[0m Shared_watchOS[0m
+[17:26:39]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared_watchOS.framework[0m
+[17:26:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[17:26:39]: [35m[33m▸[0m [39;1mAnalyzing[0m app for iOS/app Stickers [Debug][0m
+[17:26:39]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:39]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ Stickers/Info.plist[0m
+[17:26:39]: [35m[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[17:26:40]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift[0m
+[17:26:41]: [35m[33m▸[0m [39;1mCompiling[0m app\ Stickers_vers.c[0m
+[17:26:41]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:26:41]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[17:26:47]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:26:49]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Stickers.appex[0m
+[17:26:49]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Stickers.appex[0m
+[17:26:49]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto iOS [Debug][0m
+[17:26:49]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:49]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[17:26:49]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h[0m
+[17:26:49]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[17:26:49]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[17:26:49]: [35m[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:26:49]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:49]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[17:26:49]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[17:26:49]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[17:26:49]: ▸ [35m[36m                                            ^[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[17:26:49]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[17:26:49]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[17:26:49]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared iOS [Debug][0m
+[17:26:49]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:49]: [35m[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[17:26:49]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:26:49]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:26:49]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[17:26:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[17:26:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m[0m
+[17:26:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m[0m
+[17:26:50]: [35m[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m[0m
+[17:26:50]: [35m[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m[0m
+[17:26:50]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m[0m
+[17:26:50]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[17:26:50]: [35m[33m▸[0m [39;1mCopying[0m MNDefer.h[0m
+[17:26:50]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[17:26:50]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[17:26:51]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m MNGenericCopy.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[17:26:52]: [35m[33m▸[0m [39;1mCopying[0m MNBoxing.h[0m
+[17:26:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[17:26:53]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug][0m
+[17:26:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:53]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[17:26:53]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:26:53]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:26:53]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:26:53]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:26:53]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:26:53]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[17:26:53]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[17:26:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[17:26:53]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m app for iOS/app Today Extension [Debug][0m
+[17:26:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:53]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ Today\ Extension/Info.plist[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m app\ Today\ Extension_vers.c[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m[0m
+[17:26:53]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[17:26:53]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:26:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Today\ Extension.appex[0m
+[17:26:53]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Today\ Extension.appex[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[17:26:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:53]: [35m[33m▸[0m [39;1mProcessing[0m Info-iOS.plist[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[17:26:53]: [35m[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c[0m
+[17:26:53]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[17:26:53]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[17:26:54]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[17:26:54]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:26:58]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[17:26:59]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[17:26:59]: [35m[33m▸[0m [39;1mAnalyzing[0m Aiolos/Aiolos [Debug][0m
+[17:26:59]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:59]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelView.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m ContainerView.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m SeparatorView.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransition.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m ShadowView.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m PanelGestures.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m Panel.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c[0m
+[17:26:59]: [35m[33m▸[0m [39;1mLinking[0m Aiolos[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCopying[0m Aiolos.h[0m
+[17:26:59]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Aiolos.framework[0m
+[17:26:59]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[17:26:59]: [35m[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for Apple Watch Extension [Debug][0m
+[17:26:59]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:26:59]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch\ Extension/Info.plist[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift[0m
+[17:26:59]: [35m[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchNode.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchTask.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m PropertyReader.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+app.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m ComplicationController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift[0m
+[17:27:00]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m app\ for\ Apple\ Watch\ Extension_vers.c[0m
+[17:27:00]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[17:27:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[17:27:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m[0m
+[17:27:00]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:27:00]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:27:00]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:27:00]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[17:27:00]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework[0m
+[17:27:00]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:27:03]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-iOS [Debug][0m
+[17:27:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-iOS-dummy.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/FLAnimatedImage [Debug][0m
+[17:27:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage-dummy.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImageView.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a[0m
+[17:27:04]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/FTAssetRenderer [Debug][0m
+[17:27:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m[0m
+[17:27:04]: [35m[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m FTImageAssetRenderer.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m FTPDFAssetRenderer.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[17:27:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:05]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj[0m
+[17:27:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle[0m
+[17:27:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/JLRoutes [Debug][0m
+[17:27:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m JLRoutes-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m JLRoutes.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MBProgressHUD [Debug][0m
+[17:27:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-iOS [Debug][0m
+[17:27:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[17:27:05]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging-iOS-dummy.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MTDActionSheet [Debug][0m
+[17:27:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet-dummy.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheetCell.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[17:27:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:06]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist[0m
+[17:27:06]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle[0m
+[17:27:06]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/RBBAnimation [Debug][0m
+[17:27:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m NSValue+PlatformIndependence.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBAnimation-dummy.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBBlockBasedArray.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBCubicBezier.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBCustomAnimation.m[0m
+[17:27:06]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBEasingFunction.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBLinearInterpolation.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBSpringAnimation.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBTweenAnimation.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m UIColor+PlatformIndependence.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAutoLayout [Debug][0m
+[17:27:07]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAutoLayout-dummy.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+SDCAutoLayout.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[17:27:07]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgement.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsParser.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController-dummy.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementViewController.m[0m
+[17:27:07]: [35m[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a[0m
+[17:27:07]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-iOS [Debug][0m
+[17:27:07]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[17:27:07]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[17:27:08]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[17:27:09]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[17:27:09]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[17:27:09]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[17:27:10]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[17:27:10]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[17:27:10]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[17:27:11]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[17:27:12]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[17:27:12]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[17:27:12]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[17:27:12]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[17:27:12]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp[0m
+[17:27:13]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp[0m
+[17:27:14]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp[0m
+[17:27:15]: [35m[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m b2World.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m box2d-iOS-dummy.m[0m
+[17:27:16]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-iOS [Debug][0m
+[17:27:16]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m blocks.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m buffer.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark-iOS-dummy.m[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m commonmark.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m html.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m inlines.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m iterator.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m latex.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m man.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m node.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m references.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m render.c[0m
+[17:27:16]: [35m[33m▸[0m [39;1mAnalyzing[0m scanners.c[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m utf8.c[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m xml.c[0m
+[17:27:17]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer [Debug][0m
+[17:27:17]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NSBundle+NYTPhotoViewer.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoCaptionView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoDismissalInteractionController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosDataSource.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosOverlayView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionAnimator.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewer-dummy.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTScalingImageView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAlertView [Debug][0m
+[17:27:17]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertAction.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertCollectionViewCell.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerScrollView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTextFieldViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTransition.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertLabel.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertPresentationController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertTextFieldTableViewCell.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertView-dummy.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewBackgroundView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewContentView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewController.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewCoordinator.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCIntrinsicallySizedView.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+Parallax.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m UIViewController+Current.m[0m
+[17:27:17]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a[0m
+[17:27:17]: [35m[33m▸[0m [39;1mAnalyzing[0m Reachability/Reachability [Debug][0m
+[17:27:17]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:17]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[17:27:17]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:27:17]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:27:17]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[17:27:17]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[17:27:17]: [35m[33m▸[0m [39;1mCopying[0m Reachability.h[0m
+[17:27:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing iOS [Debug][0m
+[17:27:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:18]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[17:27:18]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h[0m
+[17:27:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m Yellowstone/Yellowstone [Debug][0m
+[17:27:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:18]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:27:18]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+[17:27:18]: ▸ [35mLinting 'ColorSelectionView.swift' (17/22)[0m
+[17:27:18]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorDragController.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m HeaderView.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DataStore.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPalette.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Color.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColors.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m ApplyButton.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c[0m
+[17:27:18]: [35m[33m▸[0m [39;1mLinking[0m Yellowstone[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCopying[0m Yellowstone.h[0m
+[17:27:18]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:27:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Yellowstone.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for Apple Watch [Debug][0m
+[17:27:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:18]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch/Info.plist[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard[0m
+[17:27:18]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:27:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app[0m
+[17:27:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for iOS Tests [Debug][0m
+[17:27:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS\ Tests-dummy.m[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ iOS\ Tests-dummy.m[0m
+[17:27:18]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS\ Tests.a[0m
+[17:27:18]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for iOS [Debug][0m
+[17:27:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:18]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS-dummy.m[0m
+[17:27:19]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ iOS-dummy.m[0m
+[17:27:19]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS.a[0m
+[17:27:19]: [35m[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for iOS [Debug][0m
+[17:27:19]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:19]: [35m[33m▸[0m [39;1mPreprocessing[0m Resources/appTouch-Info.plist[0m
+[17:27:19]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:27:19]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:27:44]: ▸ [35m[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+[17:27:44]: ▸ [35mstates.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)[0m
+[17:27:44]: ▸ [35m[36m                                                                               ^[0m
+[17:27:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 533ms to type-check (limit: 500ms)[0m
+[17:27:44]: ▸ [35mfunc updateConstraints(forViewSize size: CGSize) {[0m
+[17:27:44]: ▸ [35m[36m         ^[0m
+[17:27:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:27:44]: ▸ [35mlet childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }[0m
+[17:27:44]: ▸ [35m[36m         ^[0m
+[17:27:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:27:44]: ▸ [35mreturn supernode.subnodes.flatMap {[0m
+[17:27:44]: ▸ [35m[36m                                                                     ^~~~~~~[0m
+[17:27:44]: ▸ [35m** ANALYZE FAILED **[0m
+[17:27:44]: ▸ [35mThe following build commands failed:[0m
+[17:27:44]: ▸ [35mCompileSwift normal x86_64[0m
+[17:27:44]: ▸ [35mCompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler[0m
+[17:27:44]: ▸ [35m(2 failures)[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Shared/Shared watchOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m app for iOS/app Stickers [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m app for iOS/app Today Extension [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Ashton/Ashton [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Shared/Shared iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Purchasing/CommonCrypto iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m app for iOS/app for Apple Watch Extension [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Aiolos/Aiolos [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/CHCSVParser-iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/FLAnimatedImage [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/FTAssetRenderer [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/JLRoutes [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MBProgressHUD [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m app for iOS/app for Apple Watch [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MNCLogging-iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MTDActionSheet [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/RBBAnimation [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/SDCAutoLayout [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:44]: [35m[33m▸[0m [39;1mCleaning[0m Pods/box2d-iOS [Debug][0m
+[17:27:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Pods/cmark-iOS [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Purchasing/Purchasing iOS [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Reachability/Reachability [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Yellowstone/Yellowstone [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Pods/SDCAlertView [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m Pods/Pods-app for iOS [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:45]: [35m[33m▸[0m [39;1mCleaning[0m app for iOS/app for iOS [Debug][0m
+[17:27:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:46]: ▸ [35m** CLEAN FAILED **[0m
+[17:27:46]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug][0m
+[17:27:46]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:46]: [35m[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist[0m
+[17:27:46]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[17:27:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[17:27:50]: [35m[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c[0m
+[17:27:50]: [35m[33m▸[0m [39;1mLinking[0m Shared_watchOS[0m
+[17:27:50]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared_watchOS.framework[0m
+[17:27:50]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[17:27:50]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app Stickers [Debug][0m
+[17:27:50]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:50]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ Stickers/Info.plist[0m
+[17:27:50]: [35m[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[17:27:51]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift[0m
+[17:27:53]: [35m[33m▸[0m [39;1mCompiling[0m app\ Stickers_vers.c[0m
+[17:27:53]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:27:53]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[17:27:57]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:27:57]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Stickers.appex[0m
+[17:27:57]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Stickers.appex[0m
+[17:27:57]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app Today Extension [Debug][0m
+[17:27:57]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:27:57]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ Today\ Extension/Info.plist[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m app\ Today\ Extension_vers.c[0m
+[17:27:57]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:27:57]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[17:28:00]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:28:01]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Today\ Extension.appex[0m
+[17:28:02]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Today\ Extension.appex[0m
+[17:28:02]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[17:28:02]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:02]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[17:28:02]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:02]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:28:02]: ▸ [35m[36m                                      ^~~~~~~[0m
+[17:28:02]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:02]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:28:02]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[17:28:02]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[17:28:02]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[17:28:02]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[17:28:02]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug][0m
+[17:28:02]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:02]: [35m[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[17:28:02]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:28:02]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:28:02]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[17:28:02]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNDefer.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNGenericCopy.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCopying[0m MNBoxing.h[0m
+[17:28:02]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[17:28:02]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[17:28:02]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[17:28:02]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:02]: [35m[33m▸[0m [39;1mProcessing[0m Info-iOS.plist[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:28:02]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[17:28:03]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[17:28:03]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[17:28:03]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:28:03]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug][0m
+[17:28:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:04]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[17:28:04]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h[0m
+[17:28:04]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:28:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:04]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[17:28:04]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[17:28:04]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[17:28:04]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[17:28:04]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug][0m
+[17:28:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:04]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelView.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m ContainerView.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m SeparatorView.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransition.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m ShadowView.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PanelGestures.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Panel.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c[0m
+[17:28:04]: [35m[33m▸[0m [39;1mLinking[0m Aiolos[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCopying[0m Aiolos.h[0m
+[17:28:04]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Aiolos.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[17:28:04]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch Extension [Debug][0m
+[17:28:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:04]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch\ Extension/Info.plist[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchNode.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchTask.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m PropertyReader.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift[0m
+[17:28:04]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+app.swift[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m ComplicationController.swift[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift[0m
+[17:28:05]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m app\ for\ Apple\ Watch\ Extension_vers.c[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:28:05]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:28:05]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[17:28:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework[0m
+[17:28:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:28:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj[0m
+[17:28:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle[0m
+[17:28:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist[0m
+[17:28:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle[0m
+[17:28:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a[0m
+[17:28:05]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug][0m
+[17:28:05]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[17:28:05]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug][0m
+[17:28:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug][0m
+[17:28:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug][0m
+[17:28:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug][0m
+[17:28:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:06]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[17:28:06]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:28:06]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:28:06]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[17:28:06]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCopying[0m Reachability.h[0m
+[17:28:06]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[17:28:06]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[17:28:06]: [35m[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug][0m
+[17:28:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:06]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:28:06]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+[17:28:06]: ▸ [35mLinting 'FixedColorPaletteView.swift' (18/22)[0m
+[17:28:06]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorDragController.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m HeaderView.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m DataStore.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPalette.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m Color.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColors.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m ApplyButton.swift[0m
+[17:28:06]: [35m[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift[0m
+[17:28:07]: [35m[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c[0m
+[17:28:07]: [35m[33m▸[0m [39;1mLinking[0m Yellowstone[0m
+[17:28:07]: [35m[33m▸[0m [39;1mCopying[0m Yellowstone.h[0m
+[17:28:09]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:09]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Yellowstone.framework[0m
+[17:28:09]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[17:28:09]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch [Debug][0m
+[17:28:09]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:09]: [35m[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch/Info.plist[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard[0m
+[17:28:09]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:28:09]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app[0m
+[17:28:09]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app[0m
+[17:28:09]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug][0m
+[17:28:09]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:09]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift[0m
+[17:28:09]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[17:28:10]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[17:28:11]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[17:28:11]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[17:28:11]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[17:28:12]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:28:13]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[17:28:13]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[17:28:13]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h[0m
+[17:28:13]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[17:28:13]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[17:28:13]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS [Debug][0m
+[17:28:13]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:13]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS-dummy.m[0m
+[17:28:13]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS.a[0m
+[17:28:13]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for iOS [Debug][0m
+[17:28:13]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:13]: [35m[33m▸[0m [39;1mPreprocessing[0m Resources/appTouch-Info.plist[0m
+[17:28:13]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:28:13]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:28:27]: ▸ [35m[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+[17:28:27]: ▸ [35mstates.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)[0m
+[17:28:27]: ▸ [35m[36m                                                                               ^[0m
+[17:28:27]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 541ms to type-check (limit: 500ms)[0m
+[17:28:27]: ▸ [35mfunc updateConstraints(forViewSize size: CGSize) {[0m
+[17:28:27]: ▸ [35m[36m         ^[0m
+[17:28:27]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:27]: ▸ [35mlet childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }[0m
+[17:28:27]: ▸ [35m[36m         ^[0m
+[17:28:27]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:27]: ▸ [35mreturn supernode.subnodes.flatMap {[0m
+[17:28:27]: ▸ [35m[36m                                                                     ^~~~~~~[0m
+[17:28:27]: ▸ [35m** BUILD FAILED **[0m
+[17:28:27]: ▸ [35mThe following build commands failed:[0m
+[17:28:27]: ▸ [35mCompileSwift normal x86_64[0m
+[17:28:27]: ▸ [35mCompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler[0m
+[17:28:27]: ▸ [35m(2 failures)[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.595 xcodebuild[53190:214804]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[17:28:27]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.596 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (091F1524-8401-4973-8E09-822254CB6311) Beginning test session Purchasing Tests iOS-091F1524-8401-4973-8E09-822254CB6311 at 2018-04-03 17:28:27.596 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {[0m
+[17:28:27]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[17:28:27]: ▸ [35m} (11.3 (15E217))[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.604 xcodebuild[53190:210294]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[17:28:27]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.605 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (42797C4B-5CFF-4591-820A-2CC5E3946F30) Beginning test session Shared Tests iOS-42797C4B-5CFF-4591-820A-2CC5E3946F30 at 2018-04-03 17:28:27.605 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {[0m
+[17:28:27]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[17:28:27]: ▸ [35m} (11.3 (15E217))[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.619 xcodebuild[53190:210294]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[17:28:27]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log[0m
+[17:28:27]: ▸ [35m2018-04-03 17:28:27.619 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (8561E221-1FCA-43E4-AC51-8B217598ACD8) Beginning test session app for iOS Tests-8561E221-1FCA-43E4-AC51-8B217598ACD8 at 2018-04-03 17:28:27.619 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {[0m
+[17:28:27]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[17:28:27]: ▸ [35m} (11.3 (15E217))[0m
+[17:28:27]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app Stickers [Debug][0m
+[17:28:27]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:27]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app Today Extension [Debug][0m
+[17:28:27]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:27]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[17:28:27]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:27]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug][0m
+[17:28:27]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:28]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[17:28:28]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:28]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch Extension [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:28:29]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+[17:28:29]: ▸ [35mDone linting! Found 2 violations, 0 serious in 22 files.[0m
+[17:28:29]: ▸ [35m[36m                                      ^~~~~~~[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS Tests [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared Tests iOS [Debug][0m
+[17:28:29]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:29]: [35m[33m▸[0m [39;1mProcessing[0m Shared-Tests-iOS-Info.plist[0m
+[17:28:29]: [35m[33m▸[0m [39;1mCompiling[0m AppContextTests.swift[0m
+[17:28:29]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfigurationTests.swift[0m
+[17:28:29]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalErrorTests.swift[0m
+[17:28:29]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparisonTests.swift[0m
+[17:28:29]: [35m[33m▸[0m [39;1mCompiling[0m DefaultTests.swift[0m
+[17:28:30]: [35m[33m▸[0m [39;1mCompiling[0m ObjCTests.m[0m
+[17:28:32]: [35m[33m▸[0m [39;1mCompiling[0m Shared\ Tests\ iOS_vers.c[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex[0m
+[17:28:43]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app[0m
+[17:28:43]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo iOS [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCompiling[0m ViewController.swift[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.swift[0m
+[17:28:43]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCompiling[0m LaunchScreen.storyboard[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCompiling[0m Main.storyboard[0m
+[17:28:43]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[17:28:43]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[17:28:43]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/CommonCrypto.framework[0m
+[17:28:43]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/Purchasing.framework[0m
+[17:28:43]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ iOS.app[0m
+[17:28:43]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app[0m
+[17:28:43]: [35m[33m▸[0m [39;1mBuilding[0m app for iOS/app for iOS [Debug][0m
+[17:28:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:43]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:28:43]: ▸ [35m2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log}[0m
+[17:28:43]: ▸ [35m2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log}[0m
+[17:28:43]: ▸ [35m2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log}[0m
+[17:28:43]: ▸ [35mTesting failed:[0m
+[17:28:43]: ▸ [35mMissing argument for parameter 'unfoldNodes' in call[0m
+[17:28:43]: ▸ [35m** TEST FAILED **[0m
+[17:28:43]: ▸ [35mThe following build commands failed:[0m
+[17:28:43]: ▸ [35mCompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler[0m
+[17:28:43]: ▸ [35mCompileSwift normal x86_64[0m
+[17:28:43]: ▸ [35m(2 failures)[0m
+[17:28:44]: ▸ [35m[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+[17:28:44]: ▸ [35mstates.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)[0m
+[17:28:44]: ▸ [35m[36m                                                                               ^[0m
+[17:28:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 528ms to type-check (limit: 500ms)[0m
+[17:28:44]: ▸ [35mfunc updateConstraints(forViewSize size: CGSize) {[0m
+[17:28:44]: ▸ [35m[36m         ^[0m
+[17:28:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:44]: ▸ [35mlet childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }[0m
+[17:28:44]: ▸ [35m[36m         ^[0m
+[17:28:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:28:44]: ▸ [35mreturn supernode.subnodes.flatMap {[0m
+[17:28:44]: ▸ [35m[36m                                                                     ^~~~~~~[0m
+[17:28:44]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests iOS [Debug][0m
+[17:28:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:28:44]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:28:44]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[17:28:44]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[33m▸[0m [39;1mAnalyzing[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c
+[33m▸[0m [39;1mLinking[0m Shared_watchOS
+[33m▸[0m [39;1mTouching[0m Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mAnalyzing[0m app for iOS/app Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ Stickers/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift
+[33m▸[0m [39;1mCompiling[0m app\ Stickers_vers.c
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m app\ Stickers.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Stickers.appex
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c
+[33m▸[0m [39;1mLinking[0m CommonCrypto
+[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h
+[33m▸[0m [39;1mTouching[0m CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist
+[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift
+[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift
+[33m▸[0m [39;1mCompiling[0m Archive.swift
+[33m▸[0m [39;1mCompiling[0m Data+Compression.swift
+[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+
+let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+[36m                                            ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Entry.swift
+[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift
+[33m▸[0m [39;1mLinking[0m ZIPFoundation
+[33m▸[0m [39;1mTouching[0m ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mAnalyzing[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Platform.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#elseif (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Defaults.swift
+[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift
+[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift
+[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m SupportLink.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift
+[33m▸[0m [39;1mCompiling[0m WeakRef.swift
+[33m▸[0m [39;1mCompiling[0m DebugMenu.swift
+[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNCMirror.m
+[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m
+[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m Shared_vers.c
+[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m
+[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m
+[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mLinking[0m Shared
+[33m▸[0m [39;1mCopying[0m MNDefer.h
+[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h
+[33m▸[0m [39;1mCopying[0m MNCWeakArray.h
+[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h
+[33m▸[0m [39;1mCopying[0m MNGenericCopy.h
+[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNFunctions.h
+[33m▸[0m [39;1mCopying[0m MNCMirror.h
+[33m▸[0m [39;1mCopying[0m MNBoxing.h
+[33m▸[0m [39;1mTouching[0m Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist
+[33m▸[0m [39;1mCompiling[0m Mappings.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift
+[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift
+[33m▸[0m [39;1mCompiling[0m FontBuilder.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let features = fontFeatures.flatMap { feature in
+[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let features = fontFeatures.flatMap { feature in
+[36m                                                ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift
+[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Ashton.swift
+[33m▸[0m [39;1mCompiling[0m Ashton_vers.c
+[33m▸[0m [39;1mLinking[0m Ashton
+[33m▸[0m [39;1mCopying[0m Ashton.h
+[33m▸[0m [39;1mTouching[0m Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mAnalyzing[0m app for iOS/app Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ Today\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift
+[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m app\ Today\ Extension_vers.c
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m app\ Today\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Today\ Extension.appex
+[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info-iOS.plist
+[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift
+[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift
+[33m▸[0m [39;1mCompiling[0m Receipt.swift
+[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift
+[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift
+[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c
+[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mLinking[0m AppReceiptValidator
+[33m▸[0m [39;1mCopying[0m rc4.h
+[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h
+[33m▸[0m [39;1mCopying[0m cms.h
+[33m▸[0m [39;1mCopying[0m dh.h
+[33m▸[0m [39;1mCopying[0m sha.h
+[33m▸[0m [39;1mCopying[0m lhash.h
+[33m▸[0m [39;1mCopying[0m md5.h
+[33m▸[0m [39;1mCopying[0m ebcdic.h
+[33m▸[0m [39;1mCopying[0m ocsp.h
+[33m▸[0m [39;1mCopying[0m pkcs7.h
+[33m▸[0m [39;1mCopying[0m whrlpool.h
+[33m▸[0m [39;1mCopying[0m cmac.h
+[33m▸[0m [39;1mCopying[0m x509v3.h
+[33m▸[0m [39;1mCopying[0m conf.h
+[33m▸[0m [39;1mCopying[0m e_os2.h
+[33m▸[0m [39;1mCopying[0m rand.h
+[33m▸[0m [39;1mCopying[0m evp.h
+[33m▸[0m [39;1mCopying[0m x509.h
+[33m▸[0m [39;1mCopying[0m bio.h
+[33m▸[0m [39;1mCopying[0m mdc2.h
+[33m▸[0m [39;1mCopying[0m stack.h
+[33m▸[0m [39;1mCopying[0m rsa.h
+[33m▸[0m [39;1mCopying[0m opensslv.h
+[33m▸[0m [39;1mCopying[0m asn1t.h
+[33m▸[0m [39;1mCopying[0m objects.h
+[33m▸[0m [39;1mCopying[0m idea.h
+[33m▸[0m [39;1mCopying[0m ecdh.h
+[33m▸[0m [39;1mCopying[0m ecdsa.h
+[33m▸[0m [39;1mCopying[0m opensslconf.h
+[33m▸[0m [39;1mCopying[0m bn.h
+[33m▸[0m [39;1mCopying[0m ripemd.h
+[33m▸[0m [39;1mCopying[0m kssl.h
+[33m▸[0m [39;1mCopying[0m ui_compat.h
+[33m▸[0m [39;1mCopying[0m comp.h
+[33m▸[0m [39;1mCopying[0m krb5_asn.h
+[33m▸[0m [39;1mCopying[0m ec.h
+[33m▸[0m [39;1mCopying[0m x509_vfy.h
+[33m▸[0m [39;1mCopying[0m txt_db.h
+[33m▸[0m [39;1mCopying[0m cast.h
+[33m▸[0m [39;1mCopying[0m des.h
+[33m▸[0m [39;1mCopying[0m ssl2.h
+[33m▸[0m [39;1mCopying[0m pqueue.h
+[33m▸[0m [39;1mCopying[0m symhacks.h
+[33m▸[0m [39;1mCopying[0m srtp.h
+[33m▸[0m [39;1mCopying[0m ssl3.h
+[33m▸[0m [39;1mCopying[0m aes.h
+[33m▸[0m [39;1mCopying[0m dsa.h
+[33m▸[0m [39;1mCopying[0m engine.h
+[33m▸[0m [39;1mCopying[0m md4.h
+[33m▸[0m [39;1mCopying[0m ts.h
+[33m▸[0m [39;1mCopying[0m err.h
+[33m▸[0m [39;1mCopying[0m dso.h
+[33m▸[0m [39;1mCopying[0m rc2.h
+[33m▸[0m [39;1mCopying[0m hmac.h
+[33m▸[0m [39;1mCopying[0m conf_api.h
+[33m▸[0m [39;1mCopying[0m ossl_typ.h
+[33m▸[0m [39;1mCopying[0m crypto.h
+[33m▸[0m [39;1mCopying[0m srp.h
+[33m▸[0m [39;1mCopying[0m des_old.h
+[33m▸[0m [39;1mCopying[0m pem2.h
+[33m▸[0m [39;1mCopying[0m modes.h
+[33m▸[0m [39;1mCopying[0m ui.h
+[33m▸[0m [39;1mCopying[0m camellia.h
+[33m▸[0m [39;1mCopying[0m tls1.h
+[33m▸[0m [39;1mCopying[0m safestack.h
+[33m▸[0m [39;1mCopying[0m seed.h
+[33m▸[0m [39;1mCopying[0m asn1.h
+[33m▸[0m [39;1mCopying[0m blowfish.h
+[33m▸[0m [39;1mCopying[0m pkcs12.h
+[33m▸[0m [39;1mCopying[0m dtls1.h
+[33m▸[0m [39;1mCopying[0m buffer.h
+[33m▸[0m [39;1mCopying[0m pem.h
+[33m▸[0m [39;1mCopying[0m ssl.h
+[33m▸[0m [39;1mCopying[0m ssl23.h
+[33m▸[0m [39;1mCopying[0m obj_mac.h
+[33m▸[0m [39;1mCopying[0m asn1_mac.h
+[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mAnalyzing[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift
+[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift
+[33m▸[0m [39;1mCompiling[0m PanelView.swift
+[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift
+[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift
+[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m ContainerView.swift
+[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift
+[33m▸[0m [39;1mCompiling[0m SeparatorView.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransition.swift
+[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift
+[33m▸[0m [39;1mCompiling[0m ShadowView.swift
+[33m▸[0m [39;1mCompiling[0m PanelGestures.swift
+[33m▸[0m [39;1mCompiling[0m Panel.swift
+[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c
+[33m▸[0m [39;1mLinking[0m Aiolos
+[33m▸[0m [39;1mCopying[0m Aiolos.h
+[33m▸[0m [39;1mTouching[0m Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift
+[33m▸[0m [39;1mCompiling[0m WatchNode.swift
+[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift
+[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift
+[33m▸[0m [39;1mCompiling[0m WatchTask.swift
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift
+[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift
+[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift
+[33m▸[0m [39;1mCompiling[0m PropertyReader.swift
+[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNColor+app.swift
+[33m▸[0m [39;1mCompiling[0m ComplicationController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m app\ for\ Apple\ Watch\ Extension_vers.c
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework
+[33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m
+[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj
+[33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle
+[33m▸[0m [39;1mAnalyzing[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mCompiling[0m JLRoutes.m
+[33m▸[0m [39;1mAnalyzing[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m JLRoutes.m
+[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m
+[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD.m
+[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m MNCLogging.m
+[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m
+[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist
+[33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle
+[33m▸[0m [39;1mAnalyzing[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m
+[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m
+[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mAnalyzing[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mAnalyzing[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m RBBAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mAnalyzing[0m RBBCubicBezier.m
+[33m▸[0m [39;1mAnalyzing[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBEasingFunction.m
+[33m▸[0m [39;1mAnalyzing[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgement.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2Body.cpp
+[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mCompiling[0m b2Collision.cpp
+[33m▸[0m [39;1mCompiling[0m b2Contact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mCompiling[0m b2Distance.cpp
+[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Draw.cpp
+[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp
+[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Island.cpp
+[33m▸[0m [39;1mCompiling[0m b2Joint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Math.cpp
+[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Rope.cpp
+[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Settings.cpp
+[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Timer.cpp
+[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2World.cpp
+[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2World.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mAnalyzing[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m blocks.c
+[33m▸[0m [39;1mCompiling[0m buffer.c
+[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m cmark.c
+[33m▸[0m [39;1mCompiling[0m cmark_ctype.c
+[33m▸[0m [39;1mCompiling[0m commonmark.c
+[33m▸[0m [39;1mCompiling[0m houdini_href_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_u.c
+[33m▸[0m [39;1mCompiling[0m html.c
+[33m▸[0m [39;1mCompiling[0m inlines.c
+[33m▸[0m [39;1mCompiling[0m iterator.c
+[33m▸[0m [39;1mCompiling[0m latex.c
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m man.c
+[33m▸[0m [39;1mCompiling[0m node.c
+[33m▸[0m [39;1mCompiling[0m references.c
+[33m▸[0m [39;1mCompiling[0m render.c
+[33m▸[0m [39;1mCompiling[0m scanners.c
+[33m▸[0m [39;1mCompiling[0m utf8.c
+[33m▸[0m [39;1mCompiling[0m xml.c
+[33m▸[0m [39;1mAnalyzing[0m blocks.c
+[33m▸[0m [39;1mAnalyzing[0m buffer.c
+[33m▸[0m [39;1mAnalyzing[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m cmark.c
+[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c
+[33m▸[0m [39;1mAnalyzing[0m commonmark.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c
+[33m▸[0m [39;1mAnalyzing[0m html.c
+[33m▸[0m [39;1mAnalyzing[0m inlines.c
+[33m▸[0m [39;1mAnalyzing[0m iterator.c
+[33m▸[0m [39;1mAnalyzing[0m latex.c
+[33m▸[0m [39;1mAnalyzing[0m main.c
+[33m▸[0m [39;1mAnalyzing[0m man.c
+[33m▸[0m [39;1mAnalyzing[0m node.c
+[33m▸[0m [39;1mAnalyzing[0m references.c
+[33m▸[0m [39;1mAnalyzing[0m render.c
+[33m▸[0m [39;1mAnalyzing[0m scanners.c
+[33m▸[0m [39;1mAnalyzing[0m utf8.c
+[33m▸[0m [39;1mAnalyzing[0m xml.c
+[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m
+[33m▸[0m [39;1mAnalyzing[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m NYTScalingImageView.m
+[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertAction.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertLabel.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mAnalyzing[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+Parallax.m
+[33m▸[0m [39;1mAnalyzing[0m UIViewController+Current.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a
+[33m▸[0m [39;1mAnalyzing[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m Reachability.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#if (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                                ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Reachability_vers.c
+[33m▸[0m [39;1mLinking[0m Reachability
+[33m▸[0m [39;1mCopying[0m Reachability.h
+[33m▸[0m [39;1mTouching[0m Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift
+[33m▸[0m [39;1mCompiling[0m TrialState.swift
+[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift
+[33m▸[0m [39;1mCompiling[0m SignedLicense.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift
+[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift
+[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift
+[33m▸[0m [39;1mCompiling[0m License.swift
+[33m▸[0m [39;1mCompiling[0m License+Products.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift
+[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift
+[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift
+[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift
+[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift
+[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift
+[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift
+[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift
+[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService.swift
+[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Then.swift
+[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift
+[33m▸[0m [39;1mCompiling[0m VersionNumber.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift
+[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift
+[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c
+[33m▸[0m [39;1mLinking[0m Purchasing
+[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h
+[33m▸[0m [39;1mTouching[0m Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mAnalyzing[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+
+Linting 'ColorSelectionView.swift' (17/22)
+[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ColorDragController.swift
+[33m▸[0m [39;1mCompiling[0m HeaderView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DataStore.swift
+[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift
+[33m▸[0m [39;1mCompiling[0m ColorPalette.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Color.swift
+[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColors.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m ApplyButton.swift
+[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift
+[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c
+[33m▸[0m [39;1mLinking[0m Yellowstone
+[33m▸[0m [39;1mCopying[0m Yellowstone.h
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mTouching[0m Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS\ Tests-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ iOS\ Tests-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS\ Tests.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS.a
+[33m▸[0m [39;1mAnalyzing[0m app for iOS/app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m Resources/appTouch-Info.plist
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+
+states.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)
+[36m                                                                               ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 533ms to type-check (limit: 500ms)[0m
+
+func updateConstraints(forViewSize size: CGSize) {
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+return supernode.subnodes.flatMap {
+[36m                                                                     ^~~~~~~[0m
+
+
+** ANALYZE FAILED **
+
+
+The following build commands failed:
+CompileSwift normal x86_64
+CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
+(2 failures)
+[33m▸[0m [39;1mCleaning[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m app for iOS/app Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m app for iOS/app Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m app for iOS/app for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m app for iOS/app for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/Pods-app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m app for iOS/app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+** CLEAN FAILED **
+
+[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c
+[33m▸[0m [39;1mLinking[0m Shared_watchOS
+[33m▸[0m [39;1mTouching[0m Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mBuilding[0m app for iOS/app Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ Stickers/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift
+[33m▸[0m [39;1mCompiling[0m app\ Stickers_vers.c
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m app\ Stickers.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Stickers.appex
+[33m▸[0m [39;1mBuilding[0m app for iOS/app Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ Today\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift
+[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m app\ Today\ Extension_vers.c
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m app\ Today\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/app\ Today\ Extension.appex
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist
+[33m▸[0m [39;1mCompiling[0m Mappings.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift
+[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift
+[33m▸[0m [39;1mCompiling[0m FontBuilder.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let features = fontFeatures.flatMap { feature in
+[36m                                      ^~~~~~~[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let features = fontFeatures.flatMap { feature in
+[36m                                                ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift
+[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Ashton.swift
+[33m▸[0m [39;1mCompiling[0m Ashton_vers.c
+[33m▸[0m [39;1mLinking[0m Ashton
+[33m▸[0m [39;1mCopying[0m Ashton.h
+[33m▸[0m [39;1mTouching[0m Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Platform.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#elseif (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                                ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Defaults.swift
+[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift
+[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift
+[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m SupportLink.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift
+[33m▸[0m [39;1mCompiling[0m WeakRef.swift
+[33m▸[0m [39;1mCompiling[0m DebugMenu.swift
+[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNCMirror.m
+[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m
+[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m Shared_vers.c
+[33m▸[0m [39;1mLinking[0m Shared
+[33m▸[0m [39;1mCopying[0m MNDefer.h
+[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h
+[33m▸[0m [39;1mCopying[0m MNCWeakArray.h
+[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h
+[33m▸[0m [39;1mCopying[0m MNGenericCopy.h
+[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNFunctions.h
+[33m▸[0m [39;1mCopying[0m MNCMirror.h
+[33m▸[0m [39;1mCopying[0m MNBoxing.h
+[33m▸[0m [39;1mTouching[0m Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info-iOS.plist
+[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift
+[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift
+[33m▸[0m [39;1mCompiling[0m Receipt.swift
+[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift
+[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift
+[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c
+[33m▸[0m [39;1mLinking[0m AppReceiptValidator
+[33m▸[0m [39;1mCopying[0m rc4.h
+[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h
+[33m▸[0m [39;1mCopying[0m cms.h
+[33m▸[0m [39;1mCopying[0m dh.h
+[33m▸[0m [39;1mCopying[0m sha.h
+[33m▸[0m [39;1mCopying[0m lhash.h
+[33m▸[0m [39;1mCopying[0m md5.h
+[33m▸[0m [39;1mCopying[0m ebcdic.h
+[33m▸[0m [39;1mCopying[0m ocsp.h
+[33m▸[0m [39;1mCopying[0m pkcs7.h
+[33m▸[0m [39;1mCopying[0m whrlpool.h
+[33m▸[0m [39;1mCopying[0m cmac.h
+[33m▸[0m [39;1mCopying[0m x509v3.h
+[33m▸[0m [39;1mCopying[0m conf.h
+[33m▸[0m [39;1mCopying[0m e_os2.h
+[33m▸[0m [39;1mCopying[0m rand.h
+[33m▸[0m [39;1mCopying[0m evp.h
+[33m▸[0m [39;1mCopying[0m x509.h
+[33m▸[0m [39;1mCopying[0m bio.h
+[33m▸[0m [39;1mCopying[0m mdc2.h
+[33m▸[0m [39;1mCopying[0m stack.h
+[33m▸[0m [39;1mCopying[0m rsa.h
+[33m▸[0m [39;1mCopying[0m opensslv.h
+[33m▸[0m [39;1mCopying[0m asn1t.h
+[33m▸[0m [39;1mCopying[0m objects.h
+[33m▸[0m [39;1mCopying[0m idea.h
+[33m▸[0m [39;1mCopying[0m ecdh.h
+[33m▸[0m [39;1mCopying[0m ecdsa.h
+[33m▸[0m [39;1mCopying[0m opensslconf.h
+[33m▸[0m [39;1mCopying[0m bn.h
+[33m▸[0m [39;1mCopying[0m ripemd.h
+[33m▸[0m [39;1mCopying[0m kssl.h
+[33m▸[0m [39;1mCopying[0m ui_compat.h
+[33m▸[0m [39;1mCopying[0m comp.h
+[33m▸[0m [39;1mCopying[0m krb5_asn.h
+[33m▸[0m [39;1mCopying[0m ec.h
+[33m▸[0m [39;1mCopying[0m x509_vfy.h
+[33m▸[0m [39;1mCopying[0m txt_db.h
+[33m▸[0m [39;1mCopying[0m cast.h
+[33m▸[0m [39;1mCopying[0m des.h
+[33m▸[0m [39;1mCopying[0m ssl2.h
+[33m▸[0m [39;1mCopying[0m pqueue.h
+[33m▸[0m [39;1mCopying[0m symhacks.h
+[33m▸[0m [39;1mCopying[0m srtp.h
+[33m▸[0m [39;1mCopying[0m ssl3.h
+[33m▸[0m [39;1mCopying[0m aes.h
+[33m▸[0m [39;1mCopying[0m dsa.h
+[33m▸[0m [39;1mCopying[0m engine.h
+[33m▸[0m [39;1mCopying[0m md4.h
+[33m▸[0m [39;1mCopying[0m ts.h
+[33m▸[0m [39;1mCopying[0m err.h
+[33m▸[0m [39;1mCopying[0m dso.h
+[33m▸[0m [39;1mCopying[0m rc2.h
+[33m▸[0m [39;1mCopying[0m hmac.h
+[33m▸[0m [39;1mCopying[0m conf_api.h
+[33m▸[0m [39;1mCopying[0m ossl_typ.h
+[33m▸[0m [39;1mCopying[0m crypto.h
+[33m▸[0m [39;1mCopying[0m srp.h
+[33m▸[0m [39;1mCopying[0m des_old.h
+[33m▸[0m [39;1mCopying[0m pem2.h
+[33m▸[0m [39;1mCopying[0m modes.h
+[33m▸[0m [39;1mCopying[0m ui.h
+[33m▸[0m [39;1mCopying[0m camellia.h
+[33m▸[0m [39;1mCopying[0m tls1.h
+[33m▸[0m [39;1mCopying[0m safestack.h
+[33m▸[0m [39;1mCopying[0m seed.h
+[33m▸[0m [39;1mCopying[0m asn1.h
+[33m▸[0m [39;1mCopying[0m blowfish.h
+[33m▸[0m [39;1mCopying[0m pkcs12.h
+[33m▸[0m [39;1mCopying[0m dtls1.h
+[33m▸[0m [39;1mCopying[0m buffer.h
+[33m▸[0m [39;1mCopying[0m pem.h
+[33m▸[0m [39;1mCopying[0m ssl.h
+[33m▸[0m [39;1mCopying[0m ssl23.h
+[33m▸[0m [39;1mCopying[0m obj_mac.h
+[33m▸[0m [39;1mCopying[0m asn1_mac.h
+[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c
+[33m▸[0m [39;1mLinking[0m CommonCrypto
+[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h
+[33m▸[0m [39;1mTouching[0m CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist
+[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift
+[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift
+[33m▸[0m [39;1mCompiling[0m Archive.swift
+[33m▸[0m [39;1mCompiling[0m Data+Compression.swift
+[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+
+let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Entry.swift
+[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift
+[33m▸[0m [39;1mLinking[0m ZIPFoundation
+[33m▸[0m [39;1mTouching[0m ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift
+[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift
+[33m▸[0m [39;1mCompiling[0m PanelView.swift
+[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift
+[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift
+[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m ContainerView.swift
+[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift
+[33m▸[0m [39;1mCompiling[0m SeparatorView.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransition.swift
+[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift
+[33m▸[0m [39;1mCompiling[0m ShadowView.swift
+[33m▸[0m [39;1mCompiling[0m PanelGestures.swift
+[33m▸[0m [39;1mCompiling[0m Panel.swift
+[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c
+[33m▸[0m [39;1mLinking[0m Aiolos
+[33m▸[0m [39;1mCopying[0m Aiolos.h
+[33m▸[0m [39;1mTouching[0m Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift
+[33m▸[0m [39;1mCompiling[0m WatchNode.swift
+[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift
+[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift
+[33m▸[0m [39;1mCompiling[0m WatchTask.swift
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift
+[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift
+[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift
+[33m▸[0m [39;1mCompiling[0m PropertyReader.swift
+[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNColor+app.swift
+[33m▸[0m [39;1mCompiling[0m ComplicationController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m app\ for\ Apple\ Watch\ Extension_vers.c
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mLinking[0m app\
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework
+[33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser.m
+[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a
+[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a
+[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj
+[33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle
+[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mCompiling[0m JLRoutes.m
+[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a
+[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m
+[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m MNCLogging.m
+[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m
+[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist
+[33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle
+[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m
+[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m
+[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a
+[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2Body.cpp
+[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mCompiling[0m b2Collision.cpp
+[33m▸[0m [39;1mCompiling[0m b2Contact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mCompiling[0m b2Distance.cpp
+[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Draw.cpp
+[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp
+[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Island.cpp
+[33m▸[0m [39;1mCompiling[0m b2Joint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Math.cpp
+[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Rope.cpp
+[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Settings.cpp
+[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Timer.cpp
+[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2World.cpp
+[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m blocks.c
+[33m▸[0m [39;1mCompiling[0m buffer.c
+[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m cmark.c
+[33m▸[0m [39;1mCompiling[0m cmark_ctype.c
+[33m▸[0m [39;1mCompiling[0m commonmark.c
+[33m▸[0m [39;1mCompiling[0m houdini_href_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_u.c
+[33m▸[0m [39;1mCompiling[0m html.c
+[33m▸[0m [39;1mCompiling[0m inlines.c
+[33m▸[0m [39;1mCompiling[0m iterator.c
+[33m▸[0m [39;1mCompiling[0m latex.c
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m man.c
+[33m▸[0m [39;1mCompiling[0m node.c
+[33m▸[0m [39;1mCompiling[0m references.c
+[33m▸[0m [39;1mCompiling[0m render.c
+[33m▸[0m [39;1mCompiling[0m scanners.c
+[33m▸[0m [39;1mCompiling[0m utf8.c
+[33m▸[0m [39;1mCompiling[0m xml.c
+[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m
+[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a
+[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m Reachability.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#if (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Reachability_vers.c
+[33m▸[0m [39;1mLinking[0m Reachability
+[33m▸[0m [39;1mCopying[0m Reachability.h
+[33m▸[0m [39;1mTouching[0m Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+
+Linting 'FixedColorPaletteView.swift' (18/22)
+[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ColorDragController.swift
+[33m▸[0m [39;1mCompiling[0m HeaderView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DataStore.swift
+[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift
+[33m▸[0m [39;1mCompiling[0m ColorPalette.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Color.swift
+[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColors.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m ApplyButton.swift
+[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift
+[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c
+[33m▸[0m [39;1mLinking[0m Yellowstone
+[33m▸[0m [39;1mCopying[0m Yellowstone.h
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mTouching[0m Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m app\ for\ Apple\ Watch/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift
+[33m▸[0m [39;1mCompiling[0m TrialState.swift
+[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift
+[33m▸[0m [39;1mCompiling[0m SignedLicense.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift
+[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift
+[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift
+[33m▸[0m [39;1mCompiling[0m License.swift
+[33m▸[0m [39;1mCompiling[0m License+Products.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift
+[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift
+[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift
+[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift
+[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift
+[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift
+[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift
+[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift
+[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService.swift
+[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Then.swift
+[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift
+[33m▸[0m [39;1mCompiling[0m VersionNumber.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift
+[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift
+[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c
+[33m▸[0m [39;1mLinking[0m Purchasing
+[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h
+[33m▸[0m [39;1mTouching[0m Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ iOS.a
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m Resources/appTouch-Info.plist
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+
+states.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)
+[36m                                                                               ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 541ms to type-check (limit: 500ms)[0m
+
+func updateConstraints(forViewSize size: CGSize) {
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+return supernode.subnodes.flatMap {
+[36m                                                                     ^~~~~~~[0m
+
+
+** BUILD FAILED **
+
+
+The following build commands failed:
+CompileSwift normal x86_64
+CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
+(2 failures)
+2018-04-03 17:28:27.595 xcodebuild[53190:214804]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log
+2018-04-03 17:28:27.596 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (091F1524-8401-4973-8E09-822254CB6311) Beginning test session Purchasing Tests iOS-091F1524-8401-4973-8E09-822254CB6311 at 2018-04-03 17:28:27.596 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+2018-04-03 17:28:27.604 xcodebuild[53190:210294]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log
+2018-04-03 17:28:27.605 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (42797C4B-5CFF-4591-820A-2CC5E3946F30) Beginning test session Shared Tests iOS-42797C4B-5CFF-4591-820A-2CC5E3946F30 at 2018-04-03 17:28:27.605 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+2018-04-03 17:28:27.619 xcodebuild[53190:210294]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log
+2018-04-03 17:28:27.619 xcodebuild[53190:210278] [MT] IDETestOperationsObserverDebug: (8561E221-1FCA-43E4-AC51-8B217598ACD8) Beginning test session app for iOS Tests-8561E221-1FCA-43E4-AC51-8B217598ACD8 at 2018-04-03 17:28:27.619 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fd25d6358d0> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+[33m▸[0m [39;1mBuilding[0m app for iOS/app Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m app for iOS/app Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+
+Done linting! Found 2 violations, 0 serious in 22 files.
+[36m                                      ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared Tests iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-Tests-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m AppContextTests.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfigurationTests.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalErrorTests.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparisonTests.swift
+[33m▸[0m [39;1mCompiling[0m DefaultTests.swift
+[33m▸[0m [39;1mCompiling[0m ObjCTests.m
+[33m▸[0m [39;1mCompiling[0m Shared\ Tests\ iOS_vers.c
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/app\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m ViewController.swift
+[33m▸[0m [39;1mCompiling[0m AppDelegate.swift
+[33m▸[0m [39;1mLinking[0m Purchasing\
+[33m▸[0m [39;1mCompiling[0m LaunchScreen.storyboard
+[33m▸[0m [39;1mCompiling[0m Main.storyboard
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/Purchasing.framework
+[33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ iOS.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app
+[33m▸[0m [39;1mBuilding[0m app for iOS/app for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Purchasing Tests iOS-0CDDE390-0892-4573-87F0-FB346F8E9BFF/Session-Purchasing Tests iOS-2018-04-03_172827-tjUMn6.log}
+2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/Shared Tests iOS-FABF6018-0C61-4121-91B1-FA3FDDACA2E8/Session-Shared Tests iOS-2018-04-03_172827-Sautr4.log}
+2018-04-03 17:28:43.988 xcodebuild[53190:210278] Error Domain=IDETestOperationsObserverErrorDomain Code=14 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-7CFE9CA2-11B7-4E6F-AED7-A0BFDE507E43/app for iOS Tests-1CBBACB6-9DB9-4A0A-B7C0-2E2F76F4B0CD/Session-app for iOS Tests-2018-04-03_172827-2G8R4o.log}
+
+Testing failed:
+Missing argument for parameter 'unfoldNodes' in call
+** TEST FAILED **
+
+
+The following build commands failed:
+CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
+CompileSwift normal x86_64
+(2 failures)
+
+[31m❌  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/iOS/Sources/Interaction/MNTNodeInteractionState.swift:192:80: [31mmissing argument for parameter 'unfoldNodes' in call[0m
+
+states.dragging.rewireNodes(to: newParent, adaptStyle: inheritStyle)
+[36m                                                                               ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 528ms to type-check (limit: 500ms)[0m
+
+func updateConstraints(forViewSize size: CGSize) {
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }
+[36m         ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+return supernode.subnodes.flatMap {
+[36m                                                                     ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework
+[17:28:44]: [31mExit status: 65[0m
++----------------------------+------------------------------------------------------------------------------------------------+
+|                                                        [33mLane Context[0m                                                         |
++----------------------------+------------------------------------------------------------------------------------------------+
+| PLATFORM_NAME              | ios                                                                                            |
+| LANE_NAME                  | ios staticAnalyze                                                                              |
+| SCAN_DERIVED_DATA_PATH     | /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq |
+| SCAN_GENERATED_PLIST_FILES | []                                                                                             |
+| SCAN_GENERATED_PLIST_FILE  |                                                                                                |
++----------------------------+------------------------------------------------------------------------------------------------+
+[17:28:44]: [31mError building the application - see the log above[0m
+
++------+----------------------------+-------------+
+|                [32mfastlane summary[0m                 |
++------+----------------------------+-------------+
+| Step | Action                     | Time (in s) |
++------+----------------------------+-------------+
+| 1    | Verifying fastlane version | 0           |
+| 2    | clear_derived_data         | 2           |
+| 💥   | [31mscan[0m                       | 150         |
++------+----------------------------+-------------+
+
+[17:28:44]: [31mfastlane finished with errors[0m
+[31m
+[!] Error building the application - see the log above[0m
+
+#######################################################################
+# fastlane 2.89.0 is available. You are on 2.79.0.
+# You should use the latest version.
+# Please update using `bundle update fastlane`.
+#######################################################################
+
+[32m2.89.0 Improvements[0m
+* [action] Make sure get_version_number targets respond to test_target_type? (#12212) via Josh Holtz
+* [action] Make enable_automatic_code_signing for all configurations (#12187) via Nicolas Braun
+* [produce]Use correct spelling of icloud service in product/service.rb (#12134) via Jakub Knejzlík
+* [action] Add Support for Registering Mac Devices on Apple Developer Portal (#11978) via Baumchen
+* [spaceship] Spaceship delete testflight groups (#12111) via Kenneth Wong
+* [produce] Enable set 'NFC Tag Reading' at 'fastlane produce' cli. (#12179) (#12201) via Kazuhide Takahashi
+* [frameit] frameit documentation describes all parameters from the Framefile (#11662) via funnel20
+* [supply] Clarify difference between SUPPLY_JSON_KEY and SUPPLY_JSON_KEY_DATA via Aaron Brager
+* [action] added custom api_url option to testfairy (#12153) via Josh Holtz
+
+[32m2.88.0 Improvements[0m
+* [action] Fix crashlytics to not autoload gsp_path if api_token is set (#12176) via Josh Holtz
+* Improve error message when specified scheme is not found (#12182) via Cédric Luthi
+* [action] Support checking remote git tags existence (#11675) via Takeru Chuganji
+* Use Android environment to find adb (don't just rely on it being in PATH) (#12168) via Adam Cohen-Rose
+* [snapshot] Make sure matched window has a non-empty frame (#12174) via François Pradel
+* [swift] Fixes string return value and shows all lanes (even without description) (#12171) via Josh Holtz
+* [scan] Default skip_build to true in Scanfile template (#12162) via Aaron Brager
+
+[32m2.87.0 Lots of action fixes and xcodeproj gem update[0m
+* [supply] Added internal track (#12128) via Josh Holtz
+* [Action] get_latest_version handles $(SRCROOT) and tries to get target that isn't test (#12138) via Josh Holtz
+* [Action] app_store_build_number converts return to int if possible (#12148) via Josh Holtz
+* Workspace contained schemes now get loaded (#12147) via Lou Franco
+* Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting iOS projects (#12142) via Hiroyuki Morita
+* [Action] Add use_bundle_exec option to pod_push action (#11947) via Nicolas Braun
+* [match] Write Match encrypted files in binary mode to avoid UndefinedConversion error (#12112) via Michael Smith
+* [Action] Fix a bug that upload_symbols_to_crashlytics fails if path has a space (#12098) via Takeru Chuganji
+
+[32mTo see all new releases, open https://github.com/fastlane/fastlane/releases[0m
+
+[32mPlease update using `bundle update fastlane`[0m
+17:28:47 [[0;32mMESSAGE[0;0m] ColorDragController.swift [Line: 26]  Weak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)
+17:28:47 [[0;32mMESSAGE[0;0m] Reachability.swift [Line: 136]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+17:28:47 [[0;32mMESSAGE[0;0m] Platform.swift [Line: 23]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+17:28:47 [[0;32mMESSAGE[0;0m] AshtonHTMLWriter.swift [Line: 173]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:28:47 [[0;32mMESSAGE[0;0m] MNCNodeLayoutStrategyLeftRight.swift [Line: 119]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:28:47 [[0;32mMESSAGE[0;0m] Data+Serialization.swift [Line: 60]  'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'
+17:28:47 [[0;32mMESSAGE[0;0m] MNCTaskCompletionProgressCalculator.swift [Line: 59]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:28:47 [[0;32mMESSAGE[0;0m] MNTNodeInteractionState.swift [Line: 192]  issing argument for parameter 'unfoldNodes' in call
+17:28:47 [[0;33mWARNING[0;0m] Fastlane exit code: 65
+17:28:47 [[0;32mMESSAGE[0;0m] --------------------- Summary ---------------------
+17:28:47 [[0;32mMESSAGE[0;0m] Ignored Keywords: todo, -Wpragma, BITCrashManager, deprecated in iOS 11.0, type-check (limit:
+17:28:47 [[0;31m ERROR [0;0m] 1. Build Errors
+17:28:47 [[0;31m ERROR [0;0m] 7. Static Analyzer Warnings
+17:28:47 [[0;31m ERROR [0;0m] Static Analyzer failed

--- a/CallistoTest/ios_build_8745.log
+++ b/CallistoTest/ios_build_8745.log
@@ -1,0 +1,7644 @@
+~~~ Preparing build folder
+[90m$[0m mkdir -p "/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode"
+[90m$[0m cd "/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode"
+[90m$[0m ssh-keyscan "github.com" >> "/Users/administrator/.ssh/known_hosts"
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+[90m$[0m git remote set-url origin "git@github.com:IdeasOnCanvas/MindNode.git"
+[90m$[0m git clean "-fdq"
+[90m$[0m git submodule foreach --recursive git clean "-fdq"
+[90m$[0m git fetch -v origin "12f13205ba19175ab7c738ff8d00b8911127365a" || git fetch -v origin "+refs/heads/*:refs/remotes/origin/*" "+refs/tags/*:refs/tags/*"
+From github.com:IdeasOnCanvas/MindNode
+ * branch                  12f13205ba19175ab7c738ff8d00b8911127365a -> FETCH_HEAD
+[90m$[0m git checkout -f "12f13205ba19175ab7c738ff8d00b8911127365a"
+HEAD is now at 12f13205ba... trigger analyser
+[90m$[0m git submodule sync --recursive
+[90m$[0m git submodule update --init --recursive
+[90m$[0m git submodule foreach --recursive git reset --hard
+~~~ Running command
+[90m$[0m #!/bin/bash
+
+if [ "$(ls .scripts/buildkite | grep ios_tests.sh)" ]
+then ./.scripts/buildkite/ios_tests.sh
+else
+echo "----------------------------------"
+echo "##  BuildkiteScript not found   ##"
+echo "##    fallback to old style     ##"
+echo "----------------------------------"
+bundle install --path ~/gems
+bundle exec fastlane ios test
+fi
+Using rake 12.3.0
+Using CFPropertyList 2.3.6
+Using concurrent-ruby 1.0.5
+Using i18n 0.9.3
+Using minitest 5.11.2
+Using thread_safe 0.3.6
+Using tzinfo 1.2.4
+Using activesupport 4.2.10
+Using public_suffix 2.0.5
+Using addressable 2.5.2
+Using babosa 1.0.2
+Using bundler 1.16.0
+Using claide 1.0.2
+Using colored2 3.1.2
+Using cork 0.3.0
+Using nap 1.1.0
+Using open4 1.3.4
+Using claide-plugins 0.9.2
+Using fuzzy_match 2.0.4
+Using cocoapods-core 1.3.1
+Using cocoapods-deintegrate 1.0.2
+Using cocoapods-downloader 1.1.3
+Using cocoapods-plugins 1.0.0
+Using cocoapods-search 1.0.0
+Using cocoapods-stats 1.0.0
+Using netrc 0.11.0
+Using cocoapods-trunk 1.3.0
+Using cocoapods-try 1.1.0
+Using escape 0.0.4
+Using fourflusher 2.0.1
+Using gh_inspector 1.0.3
+Using molinillo 0.5.7
+Using ruby-macho 1.1.0
+Using nanaimo 0.2.3
+Using xcodeproj 1.5.4
+Using cocoapods 1.3.1
+Using redcarpet 3.4.0
+Using cocoapods-acknowledgements 1.1.2
+Using colored 1.2
+Using highline 1.7.10
+Using commander-fastlane 4.4.5
+Using multipart-post 2.0.0
+Using faraday 0.14.0
+Using faraday-http-cache 1.3.1
+Using git 1.3.0
+Using kramdown 1.16.2
+Using no_proxy_fix 0.1.2
+Using sawyer 0.8.1
+Using octokit 4.8.0
+Using unicode-display_width 1.3.0
+Using terminal-table 1.8.0
+Using danger 5.5.7
+Using thor 0.20.0
+Using danger-swiftlint 0.12.1
+Using declarative 0.0.10
+Using declarative-option 0.1.0
+Using unf_ext 0.0.7.4
+Using unf 0.1.4
+Using domain_name 0.5.20170404
+Using dotenv 2.2.1
+Using excon 0.60.0
+Using http-cookie 1.0.3
+Using faraday-cookie_jar 0.0.6
+Using faraday_middleware 0.12.2
+Using fastimage 2.1.1
+Using jwt 2.1.0
+Using little-plugger 1.1.4
+Using multi_json 1.13.1
+Using logging 2.2.2
+Using memoist 0.16.0
+Using os 0.9.6
+Using signet 0.8.1
+Using googleauth 0.6.2
+Using httpclient 2.8.3
+Using mime-types-data 3.2016.0521
+Using mime-types 3.1
+Using uber 0.1.0
+Using representable 3.0.4
+Using retriable 3.1.1
+Using google-api-client 0.13.6
+Using json 2.1.0
+Using mini_magick 4.5.1
+Using multi_xml 0.6.0
+Using plist 3.4.0
+Using rubyzip 1.2.1
+Using security 0.1.3
+Using slack-notifier 2.3.2
+Using terminal-notifier 1.8.0
+Using tty-screen 0.6.4
+Using tty-cursor 0.5.0
+Using tty-spinner 0.8.0
+Using word_wrap 1.0.0
+Using rouge 2.0.7
+Using xcpretty 0.2.8
+Using xcpretty-travis-formatter 1.0.0
+Using fastlane 2.79.0
+[32mBundle complete! 6 Gemfile dependencies, 96 gems now installed.[0m
+[32mBundled gems are installed into `/Users/administrator/gems`[0m
+[14:48:37]: [32m----------------------------------------[0m
+[14:48:37]: [32m--- Step: Verifying fastlane version ---[0m
+[14:48:37]: [32m----------------------------------------[0m
+[14:48:37]: Your fastlane version 2.79.0 matches the minimum requirement of 1.37.0  ✅
+[14:48:38]: [33mName of the lane 'build_app' is already taken by the action named 'build_app'[0m
+[14:48:38]: [32mDriving the lane 'ios staticAnalyze' 🚀[0m
+[14:48:38]: [32m--------------------------------[0m
+[14:48:38]: [32m--- Step: clear_derived_data ---[0m
+[14:48:38]: [32m--------------------------------[0m
+[14:48:38]: Derived Data path located at: /Users/administrator/Library/Developer/Xcode/DerivedData
+[14:48:40]: [32mSuccessfully cleared Derived Data ♻️[0m
+[14:48:41]: [32m------------------[0m
+[14:48:41]: [32m--- Step: scan ---[0m
+[14:48:41]: [32m------------------[0m
+[14:48:41]: [36m$ xcodebuild -list -workspace MindNode.xcworkspace[0m
+[14:48:43]: [36m$ xcodebuild -showBuildSettings -workspace MindNode.xcworkspace -scheme MindNode\ for\ iOS[0m
+[14:48:46]: [36m$ xcodebuild -list -workspace MindNode.xcworkspace[0m
+[14:48:48]: [36m$ xcodebuild -showBuildSettings -workspace MindNode.xcworkspace -scheme MindNode\ for\ iOS[0m
+
++------------------------+-------------------------------------------------------------------------------------------------------------+
+|                                                       [32mSummary for scan 2.79.0[0m                                                        |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+| devices                | ["iPhone 6s"]                                                                                               |
+| clean                  | true                                                                                                        |
+| workspace              | MindNode.xcworkspace                                                                                        |
+| scheme                 | MindNode for iOS                                                                                            |
+| xcargs                 | CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze |
+| derived_data_path      | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq              |
+| skip_build             | false                                                                                                       |
+| output_directory       | ./fastlane/test_output                                                                                      |
+| output_types           | html,junit                                                                                                  |
+| buildlog_path          | ~/Library/Logs/scan                                                                                         |
+| include_simulator_logs | false                                                                                                       |
+| open_report            | false                                                                                                       |
+| skip_slack             | false                                                                                                       |
+| slack_only_on_failure  | false                                                                                                       |
+| use_clang_report_name  | false                                                                                                       |
+| fail_build             | true                                                                                                        |
+| xcode_path             | /Applications/Xcode.app                                                                                     |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+
+[14:48:51]: [36m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace MindNode.xcworkspace -scheme MindNode\ for\ iOS -destination 'platform=iOS Simulator,id=C5E91E1A-FF7B-4D7A-81C1-C48707444457' -derivedDataPath '/Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq' CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze clean build test | tee '/Users/administrator/Library/Logs/scan/MindNode-MindNode for iOS.log' | xcpretty  --report html --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/fastlane/test_output/report.html' --report junit --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/fastlane/test_output/report.junit' --report junit --output '/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/junit_report20180404-94125-2f2xed'[0m
+[14:48:51]: ▸ [35mLoading...[0m
+[14:48:54]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode Stickers [Debug][0m
+[14:48:54]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:48:55]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ Stickers/Info.plist[0m
+[14:49:02]: [35m[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift[0m
+[14:49:05]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift[0m
+[14:49:06]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift[0m
+[14:49:06]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift[0m
+[14:49:06]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift[0m
+[14:49:06]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[14:49:06]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift[0m
+[14:49:07]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ Stickers_vers.c[0m
+[14:49:07]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:49:08]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[14:49:14]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:49:15]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Stickers.appex[0m
+[14:49:17]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex[0m
+[14:49:17]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared watchOS [Debug][0m
+[14:49:17]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:17]: [35m[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c[0m
+[14:49:17]: [35m[33m▸[0m [39;1mLinking[0m Shared_watchOS[0m
+[14:49:17]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared_watchOS.framework[0m
+[14:49:17]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[14:49:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode Today Extension [Debug][0m
+[14:49:17]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:17]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ Today\ Extension/Info.plist[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ Today\ Extension_vers.c[0m
+[14:49:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m[0m
+[14:49:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m[0m
+[14:49:17]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:49:17]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[14:49:17]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:49:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Today\ Extension.appex[0m
+[14:49:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug][0m
+[14:49:19]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:19]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[14:49:19]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[14:49:19]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[14:49:19]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared iOS [Debug][0m
+[14:49:19]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:19]: [35m[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[14:49:19]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:49:19]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:49:19]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m[0m
+[14:49:19]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[14:49:19]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[14:49:19]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[14:49:19]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[14:49:20]: [35m[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[14:49:20]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:20]: [35m[33m▸[0m [39;1mProcessing[0m Info-iOS.plist[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[14:49:20]: [35m[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c[0m
+[14:49:20]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[14:49:20]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[14:49:20]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:49:23]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto iOS [Debug][0m
+[14:49:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:24]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[14:49:24]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h[0m
+[14:49:24]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[14:49:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:24]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[14:49:24]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[14:49:24]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[14:49:24]: ▸ [35m[36m                                            ^[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[14:49:24]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-iOS [Debug][0m
+[14:49:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-iOS-dummy.m[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m[0m
+[14:49:24]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a[0m
+[14:49:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug][0m
+[14:49:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:24]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch\ Extension/Info.plist[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchNode.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchTask.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift[0m
+[14:49:24]: [35m[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m PropertyReader.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MindNode.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m ComplicationController.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift[0m
+[14:49:25]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ for\ Apple\ Watch\ Extension_vers.c[0m
+[14:49:25]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[14:49:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[14:49:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m[0m
+[14:49:25]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:49:25]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:49:25]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:49:25]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[14:49:27]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework[0m
+[14:49:28]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:49:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/FLAnimatedImage [Debug][0m
+[14:49:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage-dummy.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImageView.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/FTAssetRenderer [Debug][0m
+[14:49:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer-dummy.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FTImageAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m FTPDFAssetRenderer.m[0m
+[14:49:33]: [35m[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a[0m
+[14:49:33]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[14:49:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:33]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj[0m
+[14:49:34]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle[0m
+[14:49:34]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/JLRoutes [Debug][0m
+[14:49:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m JLRoutes-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m JLRoutes.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MBProgressHUD [Debug][0m
+[14:49:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-iOS [Debug][0m
+[14:49:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging-iOS-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MTDActionSheet [Debug][0m
+[14:49:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet-dummy.m[0m
+[14:49:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDActionSheetCell.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[14:49:35]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:35]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist[0m
+[14:49:35]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle[0m
+[14:49:35]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/RBBAnimation [Debug][0m
+[14:49:35]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m NSValue+PlatformIndependence.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBAnimation-dummy.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBBlockBasedArray.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBCubicBezier.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBCustomAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBEasingFunction.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBLinearInterpolation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBSpringAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m RBBTweenAnimation.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m UIColor+PlatformIndependence.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAutoLayout [Debug][0m
+[14:49:35]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m[0m
+[14:49:35]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAutoLayout-dummy.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+SDCAutoLayout.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[14:49:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgement.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsParser.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController-dummy.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementViewController.m[0m
+[14:49:36]: [35m[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a[0m
+[14:49:36]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-iOS [Debug][0m
+[14:49:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[14:49:36]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m[0m
+[14:49:37]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp[0m
+[14:49:37]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp[0m
+[14:49:38]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp[0m
+[14:49:39]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp[0m
+[14:49:40]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2World.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp[0m
+[14:49:41]: [35m[33m▸[0m [39;1mAnalyzing[0m box2d-iOS-dummy.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer [Debug][0m
+[14:49:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NSBundle+NYTPhotoViewer.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoCaptionView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoDismissalInteractionController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosDataSource.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosOverlayView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotosViewController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionAnimator.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewController.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewer-dummy.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m NYTScalingImageView.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-iOS [Debug][0m
+[14:49:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m blocks.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m buffer.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark-iOS-dummy.m[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m commonmark.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m html.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m inlines.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m iterator.c[0m
+[14:49:42]: [35m[33m▸[0m [39;1mAnalyzing[0m latex.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m man.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m node.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m references.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m render.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m scanners.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m utf8.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m xml.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m Aiolos/Aiolos [Debug][0m
+[14:49:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:43]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelView.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ContainerView.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SeparatorView.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransition.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ShadowView.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PanelGestures.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m Panel.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c[0m
+[14:49:43]: [35m[33m▸[0m [39;1mLinking[0m Aiolos[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCopying[0m Aiolos.h[0m
+[14:49:43]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Aiolos.framework[0m
+[14:49:43]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAlertView [Debug][0m
+[14:49:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertAction.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertCollectionViewCell.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerScrollView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTextFieldViewController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTransition.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertLabel.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertPresentationController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertTextFieldTableViewCell.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertView-dummy.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewBackgroundView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewContentView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewController.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewCoordinator.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m SDCIntrinsicallySizedView.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+Parallax.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m UIViewController+Current.m[0m
+[14:49:43]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a[0m
+[14:49:43]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing iOS [Debug][0m
+[14:49:43]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:43]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[14:49:43]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[14:49:44]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h[0m
+[14:49:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m Yellowstone/Yellowstone [Debug][0m
+[14:49:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:44]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:49:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+[14:49:44]: ▸ [35mDone linting! Found 2 violations, 0 serious in 22 files.[0m
+[14:49:44]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorDragController.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m HeaderView.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DataStore.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPalette.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Color.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColors.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m ApplyButton.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c[0m
+[14:49:44]: [35m[33m▸[0m [39;1mLinking[0m Yellowstone[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCopying[0m Yellowstone.h[0m
+[14:49:44]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:49:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Yellowstone.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for Apple Watch [Debug][0m
+[14:49:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:44]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch/Info.plist[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard[0m
+[14:49:44]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:49:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app[0m
+[14:49:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m Reachability/Reachability [Debug][0m
+[14:49:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:44]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[14:49:44]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:49:44]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:49:44]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[14:49:44]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCopying[0m Reachability.h[0m
+[14:49:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for iOS Tests [Debug][0m
+[14:49:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS\ Tests-dummy.m[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ iOS\ Tests-dummy.m[0m
+[14:49:44]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS\ Tests.a[0m
+[14:49:44]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for iOS [Debug][0m
+[14:49:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:44]: [35m[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS-dummy.m[0m
+[14:49:45]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ iOS-dummy.m[0m
+[14:49:45]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS.a[0m
+[14:49:45]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for iOS [Debug][0m
+[14:49:45]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:49:45]: [35m[33m▸[0m [39;1mPreprocessing[0m Resources/MindNodeTouch-Info.plist[0m
+[14:49:45]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[14:49:45]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[14:50:16]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 540ms to type-check (limit: 500ms)[0m
+[14:50:16]: ▸ [35mfunc updateConstraints(forViewSize size: CGSize) {[0m
+[14:50:16]: ▸ [35m[36m         ^[0m
+[14:50:16]: [35m[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch[0m
+[14:50:18]: [35m[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch[0m
+[14:50:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasViewController.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m UIFont+Convenience.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerViewController.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m UIFontDescriptor+MNTDiscovery.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetPickerViewController.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathView.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m NSString+Paths.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTStepperTableViewCell.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumCell.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTKeyboardInformation.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m[0m
+[14:50:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextFieldTableViewCell.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontDownloader.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeWebViewController.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTColorViewInCell.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCExporter.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalScreenViewController.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeView.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m[0m
+[14:50:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeWellButton.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTOverlayView.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCDevice.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeStyleInspectorViewController.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTScrollView.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m UIResponder+MNTFirstResponder.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTColorTableViewCell.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontStyleViewController.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionReusableView+MNTReuseIdentifier.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionsBrowserViewController.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCContent.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineDataSource.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTSwitchTableViewCell.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m UIFont+MNCustomFont.m[0m
+[14:50:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseViewController.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasView.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextEditor.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Convenience.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasView.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentConflictResolutionViewController.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTNavigationControllerTransitionDelegate.m[0m
+[14:50:25]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumPickerViewController.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNTShareViewController.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeView.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCAsset.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNVector.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNTNotesDetailViewController.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNTCrossConnectionInspectorViewController.m[0m
+[14:50:26]: [35m[33m▸[0m [39;1mCompiling[0m MNTSettingsViewController.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTExportController.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionNode.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTQuickLookPhoto.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegistrationViewController.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTLoadingIndicatorCell.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineSearchCell.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m UIButton+MNLongPress.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNError.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTArrowTypeCell.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalCanvasViewController.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerManager.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionBorder.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTAppearance.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentPrinter.m[0m
+[14:50:27]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionCrossConnection.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeURLActivityItemProvider.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasPrintSinglePageRenderer.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Animation.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTPathStyleCell.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTClipArtPickerViewController.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentSharableData.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTStepper.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCNote.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleController.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTAccessibilityCustomAction.m[0m
+[14:50:28]: [35m[33m▸[0m [39;1mCompiling[0m MNTKeyboardAccessory.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+MNBlockDrawing.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionCell.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[14:50:29]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm[0m
+[14:50:30]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadProgressViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTWindow.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineBaseCell.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineSettingsViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCText.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTPlaceholderTextView.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextFormatCell.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionText.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentViewController.m[0m
+[14:50:31]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/iOS/Sources/Document UI/MNTDocumentViewController.m:2085:9: [33mTODO: don't close if we resolved a conflict, but reload document [-W#pragma-messages][0m
+[14:50:31]: ▸ [35m#pragma message("TODO: don't close if we resolved a conflict, but reload document")[0m
+[14:50:31]: ▸ [35m[36m        ^[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTAccessibilityDefines.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNAdditions.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocument.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTTableViewCell.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m UIBarButtonItem+MNLongPress.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTDateFormatter.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontPickerViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTButtonCell.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSource.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeSettingsViewController.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArt.m[0m
+[14:50:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextController.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTCircularProgressView.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTWebViewController.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTLightBoxView.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m UIMenuController+UserInfo.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m UIApplication+MNAdditions.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCKnobView.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeTableViewController.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachment.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCFileLink.m[0m
+[14:50:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTAppDelegate.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerCell.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeShapeTypeCell.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineCell.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCSearchableIndex.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNTApplication.m[0m
+[14:50:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCTask.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+MNAdditions.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController+Actions.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNTCheckmarkTableViewCell.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNTCreditsViewController.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m[0m
+[14:50:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+TintColor.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalKeyboardManager.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m NSString+UUID.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+MNAccessibility.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTCollectionViewHeaderView.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTMindMapLayoutCell.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UIScrollView+Scrolling.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UISearchBar+MNTCancellation.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNDefaults.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeSafariActivity.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetsCollection.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontManager.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNTFadeTransition.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSourceSection.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Convenience.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+MNTModalSwipeDismiss.m[0m
+[14:50:36]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNTCustomFontLabel.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextEditorView.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSourceItem.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseTableViewController.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMindNodeExporter.m[0m
+[14:50:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCanvasViewController.m[0m
+[14:50:39]: [35m[33m▸[0m [39;1mAnalyzing[0m UIFont+Convenience.m[0m
+[14:50:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerViewController.m[0m
+[14:50:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCloudShapeGenerator.m[0m
+[14:50:40]: [35m[33m▸[0m [39;1mAnalyzing[0m UIFontDescriptor+MNTDiscovery.m[0m
+[14:50:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAssetPickerViewController.m[0m
+[14:50:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutManager.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNExporting.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAnalyticsTracker.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathView.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+Paths.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode+MNPropertyRepresentation.m[0m
+[14:50:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTStepperTableViewCell.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAlbumCell.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersSyncController.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTKeyboardInformation.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLExporter.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNImporting.m[0m
+[14:50:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme+Creation.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineLayouter.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTTextFieldTableViewCell.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFontDownloader.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTMyMindNodeWebViewController.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTColorViewInCell.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCExporter.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadFinishedViewController.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineSearchDataSource.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTExternalScreenViewController.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBaseDataSource.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAshtonValueTransformer.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+QueryParsing.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadStartViewController.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNodeView.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Convenience.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNodeWellButton.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseTextExporter.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindParser.m[0m
+[14:51:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOverlayView.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDevice.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNodeStyleInspectorViewController.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCValueTransformerRegistration.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPlainTextExporter.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTScrollView.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m UIResponder+MNTFirstResponder.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCShapeStyle.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTColorTableViewCell.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFontStyleViewController.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m UICollectionReusableView+MNTReuseIdentifier.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentVersionsBrowserViewController.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDXMLElement.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCContent.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+CIELAB.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineDataSource.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTSwitchTableViewCell.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachmentRenderer.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m UIFont+MNCustomFont.m[0m
+[14:51:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorBaseViewController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+Stack.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCanvasView.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTTextEditor.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m UIViewController+Convenience.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCachingImageManager.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBranchRenderer.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasView.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasViewController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentConflictResolutionViewController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasRenderer.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleValue.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNavigationControllerTransitionDelegate.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAlbumPickerViewController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersExporter.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTranslateNodeController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m main.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchToggleButton.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTShareViewController.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindExporter.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeView.m[0m
+[14:51:02]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNSwizzling.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineDefines.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText+MNPropertyRepresentation.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAsset.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNVector.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUserGuideView.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNotesDetailViewController.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVParser.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCrossConnectionInspectorViewController.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTSettingsViewController.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTExportController.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionNode.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTQuickLookPhoto.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeRegistrationViewController.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTLoadingIndicatorCell.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m NSTextAttachment+MNAdditions.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineSearchCell.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerContentDataSource.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextView+MNAdditions.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m UIButton+MNLongPress.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNError.m[0m
+[14:51:03]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPDFExporter.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTArrowTypeCell.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTExternalCanvasViewController.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMainThreadHangDetector.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerManager.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtAttachment.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionBorder.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTAppearance.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNCoalescing.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentPrinter.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionCrossConnection.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseParser.m[0m
+[14:51:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCIThoughtsParser.m[0m
+[14:51:12]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLParser.m[0m
+[14:51:12]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeURLActivityItemProvider.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNode.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCanvasPrintSinglePageRenderer.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSimpleXMLExporter.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+Animation.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPathStyleCell.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTClipArtPickerViewController.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentSharableData.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTStepper.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNote.m[0m
+[14:51:13]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument4to5MigrationController.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleController.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTAccessibilityCustomAction.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTKeyboardAccessory.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m UIImage+MNBlockDrawing.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableAttributedString+Convenience.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentObjectSavingManager.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentVersionCell.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutControllerManager.m[0m
+[14:51:14]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadProgressViewController.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTWindow.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineBaseCell.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineViewController.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchColorView.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineSettingsViewController.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMigrationManager.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxy.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathStyle.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPlaceholderTextView.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionStyle.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+ObjectsConvenience.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTTextFormatCell.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionText.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentViewController.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionKnobView.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasViewController.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRichTextExporter.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTAccessibilityDefines.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m NSIndexPath+MNAdditions.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUndoManager.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m CAAnimation+MNCompletionBlocks.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocument.m[0m
+[14:51:15]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTTableViewCell.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m UIBarButtonItem+MNLongPress.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDateFormatter.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPasteboardController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+MNAdditions.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFontPickerViewController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBranchRepresentedObject.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTButtonCell.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextOutlineParser.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDataSource.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDateFormatter+MNAdditions.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeSettingsViewController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArt.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCResizeKnobView.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeStyle.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageExporter.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCircularProgressView.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPastePersistentManager.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageAttachment.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTWebViewController.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTLightBoxView.m[0m
+[14:51:16]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+Convenience.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m UIMenuController+UserInfo.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m UIApplication+MNAdditions.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeWellButton.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVExporter.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCKnobView.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTContentSizeTableViewController.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachment.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentImageManager.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController+box2dInterface.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFileLink.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTAppDelegate.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerCell.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeRepresentedObject.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeRenderer.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTNodeShapeTypeCell.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Components.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m NSParagraphStyle+MNConvenience.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSubselectionResizeKnobView.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtSet.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyController.m[0m
+[14:51:17]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionRenderer.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStrokeStyle.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTOutlineCell.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSearchableIndex.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskSyncController.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTApplication.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTask.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m NSData+Convenience.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m UIImage+MNAdditions.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasViewController+Actions.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCheckmarkTableViewCell.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseStyle.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineTasksDataSource.m[0m
+[14:51:18]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCreditsViewController.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNAdditions.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m UIImage+TintColor.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+UUID.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMarkdownExporter.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTExternalKeyboardManager.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCollectionViewHeaderView.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCColorValueTransformer.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m UIViewController+MNAccessibility.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFileProgressViewController.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTMindMapLayoutCell.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCArrowStyle.m[0m
+[14:51:19]: [35m[33m▸[0m [39;1mAnalyzing[0m UIScrollView+Scrolling.m[0m
+[14:51:20]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineNodeCache.m[0m
+[14:51:20]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerComposedDataSource.m[0m
+[14:51:20]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCConvexHullController.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFontStyle.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelectionController.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m UISearchBar+MNTCancellation.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNDefaults.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTMyMindNodeSafariActivity.m[0m
+[14:51:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMindjetParser.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionView.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAssetsCollection.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFontManager.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTFadeTransition.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController+Selection.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDataSourceSection.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m UIView+Convenience.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelection.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNodeDocument.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m UIViewController+MNTModalSwipeDismiss.m[0m
+[14:51:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasView.m[0m
+[14:51:28]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme1To2MigrationController.m[0m
+[14:51:28]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTCustomFontLabel.m[0m
+[14:51:28]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTTextEditorView.m[0m
+[14:51:28]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskButton.m[0m
+[14:51:28]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[14:51:29]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+MNCProperties.m[0m
+[14:51:29]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDataSourceItem.m[0m
+[14:51:29]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTInspectorBaseTableViewController.m[0m
+[14:51:30]: [35m[33m▸[0m [39;1mLinking[0m MindNode[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-acknowledgements.plist[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromo.html[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme[0m
+[14:51:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.xib[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.xib[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoAppIcon.pdf[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m credits.plist[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconMedal.svg[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconDevices.svg[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.xib[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-metadata.plist[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart[0m
+[14:51:32]: [35m[33m▸[0m [39;1mCompiling[0m MNTLaunchScreen.storyboard[0m
+[14:51:38]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:51:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:51:39]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[14:51:39]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[14:51:39]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Ashton.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Shared.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Purchasing.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/AppReceiptValidator.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Reachability.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/CommonCrypto.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/ZIPFoundation.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Yellowstone.framework[0m
+[14:51:39]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Aiolos.framework[0m
+[14:51:40]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[14:51:40]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app[0m
+[14:51:42]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for iOS Tests [Debug][0m
+[14:51:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:51:42]: [35m[33m▸[0m [39;1mPreprocessing[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/iOS/Info.plist[0m
+[14:51:42]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:51:42]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[14:51:42]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[14:51:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[14:51:47]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentControllerTests.swift[0m
+[14:51:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCAppLauncherTests.swift[0m
+[14:51:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCFunctionsTests.swift[0m
+[14:51:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationControllerTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionControllerTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindMapTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeLayoutCalculatorTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCSetSynchronizerTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeTests.swift[0m
+[14:51:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeHierarchyControllerTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCPropertyRepresentationTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontManagerTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOControllerTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTUserIntentValidatorTests.swift[0m
+[14:51:53]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:569:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:51:53]: ▸ [35m].flatMap { $0 }[0m
+[14:51:53]: ▸ [35m[36m              ^[0m
+[14:51:53]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:645:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:51:53]: ▸ [35m].flatMap { $0 }[0m
+[14:51:53]: ▸ [35m[36m              ^~~~~~~[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutCalculatorTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineImporterTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCZoomingCalculatorTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCHelloPayloadBuilderTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeDataSourceTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCThingsExporterTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextBundleExporterTests.swift[0m
+[14:51:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindImporterTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyleTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedStringMarkdownTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexerTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCXMindImporterTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument5to6MigrationControllerTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextExporterTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m NSRangeSwiftTests.swift[0m
+[14:51:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerTests.swift[0m
+[14:51:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporterTests.swift[0m
+[14:51:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCiThoughtsImporterTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNColorTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVImporterTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNTReviewDisplayLogicTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionControllerTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m WatchTransferStatusTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme2to3MigrationTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeControllerTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporterTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskPaperExporterTests.swift[0m
+[14:51:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindJetImporterTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentOpenPerformanceTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownImporterTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontExtractorTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCBoundaryMorphTests.swift[0m
+[14:51:57]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:51:57]: ▸ [35mlet polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }[0m
+[14:51:57]: ▸ [35m[36m              ^~~~~~~[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasControllerTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleDocument1To2MigrationTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentVersionDecisionTests.swift[0m
+[14:51:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporterTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextBundleImporterTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNImage+ImageDiff.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeManagerTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLImporterTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentExporterTests.swift[0m
+[14:51:58]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskControllerTests.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCInsertPositionCalculatorTests.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m XCTestCase+DocumentHelper.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardTests.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskPaperImporterTests.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeTokenStoreTests.swift[0m
+[14:51:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCAccessibilityTextExporterTests.swift[0m
+[14:52:00]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentControllerTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNTestHelper.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mCompiling[0m SSWZipTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mCompiling[0m MNTextTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ for\ iOS\ Tests_vers.c[0m
+[14:52:05]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentControllerTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyTests.m[0m
+[14:52:05]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNTestHelper.m[0m
+[14:52:08]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZipTests.m[0m
+[14:52:08]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextTests.m[0m
+[14:52:08]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:52:08]: [35m[33m▸[0m [39;1mGenerating 'MindNode\ for\ iOS\ Tests.xctest.dSYM'[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m WatchModel.plist[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode[0m
+[14:52:09]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[14:52:09]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[14:52:10]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ iOS\ Tests.xctest[0m
+[14:52:10]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/PlugIns/MindNode\ for\ iOS\ Tests.xctest[0m
+[14:52:11]: [35m[33m▸[0m [39;1mAnalyze[0m Succeeded[0m
+[14:52:11]: [35m[33m▸[0m [39;1mCleaning[0m Shared/Shared watchOS [Debug][0m
+[14:52:11]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode Stickers [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode Today Extension [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Purchasing/CommonCrypto iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Shared/Shared iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Ashton/Ashton [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/CHCSVParser-iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/FLAnimatedImage [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/FTAssetRenderer [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/JLRoutes [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MBProgressHUD [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MNCLogging-iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/MTDActionSheet [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for Apple Watch [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/RBBAnimation [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/SDCAutoLayout [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/box2d-iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/cmark-iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Purchasing/Purchasing iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Yellowstone/Yellowstone [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Aiolos/Aiolos [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Reachability/Reachability [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/SDCAlertView [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m Pods/Pods-MindNode for iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:12]: [35m[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for iOS [Debug][0m
+[14:52:12]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:14]: [35m[33m▸[0m [39;1mClean[0m Succeeded[0m
+[14:52:14]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug][0m
+[14:52:14]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:14]: [35m[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist[0m
+[14:52:14]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[14:52:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c[0m
+[14:52:18]: [35m[33m▸[0m [39;1mLinking[0m Shared_watchOS[0m
+[14:52:18]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared_watchOS.framework[0m
+[14:52:18]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[14:52:18]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Stickers [Debug][0m
+[14:52:18]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:18]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ Stickers/Info.plist[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[14:52:18]: [35m[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift[0m
+[14:52:19]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ Stickers_vers.c[0m
+[14:52:19]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:52:20]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[14:52:23]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:52:23]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Stickers.appex[0m
+[14:52:24]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex[0m
+[14:52:24]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Today Extension [Debug][0m
+[14:52:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:24]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ Today\ Extension/Info.plist[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[14:52:24]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ Today\ Extension_vers.c[0m
+[14:52:24]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:52:25]: [35m[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard[0m
+[14:52:25]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:52:26]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Today\ Extension.appex[0m
+[14:52:28]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex[0m
+[14:52:28]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug][0m
+[14:52:28]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:28]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[14:52:28]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h[0m
+[14:52:28]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[14:52:28]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[14:52:28]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[14:52:28]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:28]: [35m[33m▸[0m [39;1mProcessing[0m Info-iOS.plist[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[14:52:28]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[14:52:29]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[14:52:29]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[14:52:30]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[14:52:31]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[14:52:31]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:52:32]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[14:52:32]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[14:52:32]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug][0m
+[14:52:32]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:32]: [35m[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[14:52:32]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:52:32]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:52:32]: ▸ [35m[36m                                                       ^~~~~~~[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[14:52:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[14:52:33]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[14:52:33]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[14:52:33]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch\ Extension/Info.plist[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchNode.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchTask.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m PropertyReader.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MindNode.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m ComplicationController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift[0m
+[14:52:33]: [35m[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MindNode\ for\ Apple\ Watch\ Extension_vers.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:52:33]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:52:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m JLRoutes.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist[0m
+[14:52:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle[0m
+[14:52:33]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBAnimation.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a[0m
+[14:52:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug][0m
+[14:52:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[14:52:33]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug][0m
+[14:52:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug][0m
+[14:52:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug][0m
+[14:52:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:34]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ContainerView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m SeparatorView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelTransition.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ShadowView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m PanelGestures.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m Panel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mLinking[0m Aiolos[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCopying[0m Aiolos.h[0m
+[14:52:34]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Aiolos.framework[0m
+[14:52:34]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[14:52:34]: [35m[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug][0m
+[14:52:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:34]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:52:34]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+[14:52:34]: ▸ [35mLinting 'HeaderView.swift' (19/22)[0m
+[14:52:34]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorDragController.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m HeaderView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m DataStore.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPalette.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m Color.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m DerivedColors.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m ApplyButton.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c[0m
+[14:52:34]: [35m[33m▸[0m [39;1mLinking[0m Yellowstone[0m
+[14:52:34]: [35m[33m▸[0m [39;1mCopying[0m Yellowstone.h[0m
+[14:52:36]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:52:36]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Yellowstone.framework[0m
+[14:52:36]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[14:52:36]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug][0m
+[14:52:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:36]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[14:52:36]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:52:36]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:52:36]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[14:52:36]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCopying[0m Reachability.h[0m
+[14:52:36]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[14:52:36]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[14:52:36]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch [Debug][0m
+[14:52:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:36]: [35m[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch/Info.plist[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard[0m
+[14:52:36]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:52:36]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app[0m
+[14:52:36]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:52:36]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS [Debug][0m
+[14:52:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS-dummy.m[0m
+[14:52:36]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS.a[0m
+[14:52:36]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug][0m
+[14:52:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:36]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[14:52:36]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift[0m
+[14:52:37]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[14:52:38]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[14:52:40]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:52:41]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[14:52:41]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[14:52:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h[0m
+[14:52:41]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[14:52:41]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[14:52:41]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS [Debug][0m
+[14:52:41]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:52:41]: [35m[33m▸[0m [39;1mPreprocessing[0m Resources/MindNodeTouch-Info.plist[0m
+[14:52:41]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[14:52:41]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[14:53:05]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 552ms to type-check (limit: 500ms)[0m
+[14:53:05]: ▸ [35mfunc updateConstraints(forViewSize size: CGSize) {[0m
+[14:53:05]: ▸ [35m[36m         ^[0m
+[14:53:05]: [35m[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch[0m
+[14:53:06]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m[0m
+[14:53:06]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasViewController.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m UIFont+Convenience.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerViewController.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m UIFontDescriptor+MNTDiscovery.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetPickerViewController.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathView.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m NSString+Paths.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNTStepperTableViewCell.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumCell.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNTKeyboardInformation.m[0m
+[14:53:07]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextFieldTableViewCell.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontDownloader.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeWebViewController.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNTColorViewInCell.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCExporter.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalScreenViewController.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m[0m
+[14:53:08]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeView.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeWellButton.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTOverlayView.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCDevice.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeStyleInspectorViewController.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTScrollView.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m UIResponder+MNTFirstResponder.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTColorTableViewCell.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontStyleViewController.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m UICollectionReusableView+MNTReuseIdentifier.m[0m
+[14:53:09]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionsBrowserViewController.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCContent.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineDataSource.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTSwitchTableViewCell.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m UIFont+MNCustomFont.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseViewController.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasView.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextEditor.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+Convenience.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasView.m[0m
+[14:53:10]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentConflictResolutionViewController.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNTNavigationControllerTransitionDelegate.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumPickerViewController.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNTShareViewController.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeView.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCAsset.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNVector.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m[0m
+[14:53:11]: [35m[33m▸[0m [39;1mCompiling[0m MNTNotesDetailViewController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTCrossConnectionInspectorViewController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTSettingsViewController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTExportController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionNode.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTQuickLookPhoto.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegistrationViewController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTLoadingIndicatorCell.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineSearchCell.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m UIButton+MNLongPress.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNError.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTArrowTypeCell.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalCanvasViewController.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m[0m
+[14:53:12]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerManager.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionBorder.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNTAppearance.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentPrinter.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionCrossConnection.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeURLActivityItemProvider.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNTCanvasPrintSinglePageRenderer.m[0m
+[14:53:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Animation.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTPathStyleCell.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTClipArtPickerViewController.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentSharableData.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTStepper.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCNote.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleController.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTAccessibilityCustomAction.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTKeyboardAccessory.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+MNBlockDrawing.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionCell.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m[0m
+[14:53:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadProgressViewController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTWindow.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineBaseCell.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineViewController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineSettingsViewController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCText.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTPlaceholderTextView.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextFormatCell.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionText.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentViewController.m[0m
+[14:53:16]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/iOS/Sources/Document UI/MNTDocumentViewController.m:2085:9: [33mTODO: don't close if we resolved a conflict, but reload document [-W#pragma-messages][0m
+[14:53:16]: ▸ [35m#pragma message("TODO: don't close if we resolved a conflict, but reload document")[0m
+[14:53:16]: ▸ [35m[36m        ^[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTAccessibilityDefines.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNAdditions.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocument.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTTableViewCell.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m UIBarButtonItem+MNLongPress.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTDateFormatter.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontPickerViewController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNTButtonCell.m[0m
+[14:53:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSource.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeSettingsViewController.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArt.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextController.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTCircularProgressView.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTWebViewController.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNTLightBoxView.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m UIMenuController+UserInfo.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m UIApplication+MNAdditions.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m[0m
+[14:53:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCKnobView.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTContentSizeTableViewController.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachment.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCFileLink.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTAppDelegate.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTImagePickerCell.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTNodeShapeTypeCell.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNTOutlineCell.m[0m
+[14:53:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCSearchableIndex.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNTApplication.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCTask.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+MNAdditions.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController+Actions.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNTCheckmarkTableViewCell.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNTCreditsViewController.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m[0m
+[14:53:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UIImage+TintColor.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTExternalKeyboardManager.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m NSString+UUID.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+MNAccessibility.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTCollectionViewHeaderView.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTMindMapLayoutCell.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UIScrollView+Scrolling.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UISearchBar+MNTCancellation.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNDefaults.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeSafariActivity.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetsCollection.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTFontManager.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTFadeTransition.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSourceSection.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UIView+Convenience.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m UIViewController+MNTModalSwipeDismiss.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTCustomFontLabel.m[0m
+[14:53:21]: [35m[33m▸[0m [39;1mCompiling[0m MNTTextEditorView.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCDataSourceItem.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseTableViewController.m[0m
+[14:53:22]: [35m[33m▸[0m [39;1mLinking[0m MindNode[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-acknowledgements.plist[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromo.html[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.xib[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoAppIcon.pdf[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.xib[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m credits.plist[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconMedal.svg[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconDevices.svg[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.xib[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-metadata.plist[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart[0m
+[14:53:23]: [35m[33m▸[0m [39;1mCompiling[0m MNTLaunchScreen.storyboard[0m
+[14:53:29]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:53:29]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:53:30]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[14:53:30]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[14:53:30]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Purchasing.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Ashton.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Shared.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Reachability.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/AppReceiptValidator.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/CommonCrypto.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Yellowstone.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/ZIPFoundation.framework[0m
+[14:53:30]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Aiolos.framework[0m
+[14:53:31]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[14:53:31]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app[0m
+[14:53:32]: [35m[33m▸[0m [39;1mBuild[0m Succeeded[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.877 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[14:53:32]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/Purchasing Tests iOS-AFE11490-CFBC-4EE6-A633-FD4F88CE9FE9/Session-Purchasing Tests iOS-2018-04-04_145332-pZIXfZ.log[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.883 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (F076D2C1-B0BE-4180-B2EB-E9E9CBB47A83) Beginning test session Purchasing Tests iOS-F076D2C1-B0BE-4180-B2EB-E9E9CBB47A83 at 2018-04-04 14:53:32.878 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {[0m
+[14:53:32]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[14:53:32]: ▸ [35m} (11.3 (15E217))[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.906 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[14:53:32]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/Shared Tests iOS-D540EDE9-55EE-416D-9BEC-0A488BA1263B/Session-Shared Tests iOS-2018-04-04_145332-LQbMHs.log[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.907 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (9429E0D4-6FA2-4171-8528-6026249D4C5D) Beginning test session Shared Tests iOS-9429E0D4-6FA2-4171-8528-6026249D4C5D at 2018-04-04 14:53:32.907 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {[0m
+[14:53:32]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[14:53:32]: ▸ [35m} (11.3 (15E217))[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.911 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[14:53:32]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/MindNode for iOS Tests-3C67590D-7820-4CBB-8B06-DEE503858BBF/Session-MindNode for iOS Tests-2018-04-04_145332-jmXwu8.log[0m
+[14:53:32]: ▸ [35m2018-04-04 14:53:32.911 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (F9707EE0-F01C-4733-A477-3559139D4ACE) Beginning test session MindNode for iOS Tests-F9707EE0-F01C-4733-A477-3559139D4ACE at 2018-04-04 14:53:32.912 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {[0m
+[14:53:32]: ▸ [35mSimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)[0m
+[14:53:32]: ▸ [35m} (11.3 (15E217))[0m
+[14:53:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Stickers [Debug][0m
+[14:53:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:33]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug][0m
+[14:53:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Today Extension [Debug][0m
+[14:53:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:33]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug][0m
+[14:53:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:33]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug][0m
+[14:53:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS Tests [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared Tests iOS [Debug][0m
+[14:53:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:37]: [35m[33m▸[0m [39;1mProcessing[0m Shared-Tests-iOS-Info.plist[0m
+[14:53:37]: [35m[33m▸[0m [39;1mCompiling[0m AppContextTests.swift[0m
+[14:53:37]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfigurationTests.swift[0m
+[14:53:38]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalErrorTests.swift[0m
+[14:53:38]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparisonTests.swift[0m
+[14:53:38]: [35m[33m▸[0m [39;1mCompiling[0m DefaultTests.swift[0m
+[14:53:38]: [35m[33m▸[0m [39;1mCompiling[0m Shared\ Tests\ iOS_vers.c[0m
+[14:53:38]: [35m[33m▸[0m [39;1mCompiling[0m ObjCTests.m[0m
+[14:53:42]: [35m[33m▸[0m [39;1mLinking[0m Shared\[0m
+[14:53:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared\ Tests\ iOS.xctest[0m
+[14:53:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared\ Tests\ iOS.xctest[0m
+[14:53:44]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch [Debug][0m
+[14:53:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex[0m
+[14:53:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app[0m
+[14:53:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:53:44]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS [Debug][0m
+[14:53:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:44]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug][0m
+[14:53:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:44]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo iOS [Debug][0m
+[14:53:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCompiling[0m ViewController.swift[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.swift[0m
+[14:53:44]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCompiling[0m LaunchScreen.storyboard[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCompiling[0m Main.storyboard[0m
+[14:53:44]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework[0m
+[14:53:44]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework[0m
+[14:53:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/CommonCrypto.framework[0m
+[14:53:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/Purchasing.framework[0m
+[14:53:44]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ iOS.app[0m
+[14:53:44]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app[0m
+[14:53:44]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS [Debug][0m
+[14:53:44]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:44]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[14:53:45]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:53:45]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app[0m
+[14:53:45]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[14:53:45]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[14:53:45]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[14:53:45]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app[0m
+[14:53:46]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests iOS [Debug][0m
+[14:53:46]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:46]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumberTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptAssets.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m MockPurchasingServiceConfiguration.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m XCTestCase+ObservableAssertions.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdaterTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m TestAssetLoading.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m LicenseAssets.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m License+Convenience.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidatorTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifierTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m CurrentReceiptValidationTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysisTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m MockDefaults.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m Date+Convenience.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+Convenience.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m DataStoreTestContext.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTestContext.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStoreTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTests.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m MockStorePromotionControllerWrapper.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+DemoData.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCompiling[0m MockStoreKitWrapper.swift[0m
+[14:53:46]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/wildcard.alamofire.org.cer[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.2.3.b64[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-root-ca.cer[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity01[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/expired.cer[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-dns-name.cer[0m
+[14:53:46]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial_and_full.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity02[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/missing-dns-name-and-uri.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01.txt[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_3394.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithoutTrial_SignedWithProduction.json[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity02_rsaCert.der[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-uri.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial_and_fullversion.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_michaelsandbox_receipt1.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_147.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicenseWithTrial_With_Identity01.json[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity02[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicense_With_Identity01.json[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity01[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/MindNodeLicensingProduction_rsaCert.der[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca2.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_vpp.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_fullversionfree.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.5.7.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca1.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02.txt[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/test.alamofire.org.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_vpp.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/multiple-dns-names.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca1.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithTrial_SignedWithProduction.json[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca2.cer[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial.b64[0m
+[14:53:47]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity01_rsaCert.der[0m
+[14:53:48]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Tests\ iOS.xctest[0m
+[14:53:48]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/PlugIns/Purchasing\ Tests\ iOS.xctest[0m
+[14:53:48]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS Tests [Debug][0m
+[14:53:48]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:53:48]: [35m[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist[0m
+[14:53:48]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[14:53:48]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[14:53:48]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[14:53:48]: [35m[33m▸[0m [39;1mCompiling[0m MNTDocumentControllerTests.swift[0m
+[14:53:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCAppLauncherTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCFunctionsTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationControllerTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionControllerTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindMapTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeLayoutCalculatorTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCSetSynchronizerTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeTests.swift[0m
+[14:53:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeHierarchyControllerTests.swift[0m
+[14:53:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCPropertyRepresentationTests.swift[0m
+[14:53:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontManagerTests.swift[0m
+[14:53:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOControllerTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNTUserIntentValidatorTests.swift[0m
+[14:53:51]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:569:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:53:51]: ▸ [35m].flatMap { $0 }[0m
+[14:53:51]: ▸ [35m[36m              ^[0m
+[14:53:51]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:645:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:53:51]: ▸ [35m].flatMap { $0 }[0m
+[14:53:51]: ▸ [35m[36m              ^~~~~~~[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutCalculatorTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineImporterTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCZoomingCalculatorTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCHelloPayloadBuilderTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeDataSourceTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCThingsExporterTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextBundleExporterTests.swift[0m
+[14:53:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindImporterTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyleTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedStringMarkdownTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexerTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCXMindImporterTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument5to6MigrationControllerTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextExporterTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m NSRangeSwiftTests.swift[0m
+[14:53:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporterTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCiThoughtsImporterTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNColorTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVImporterTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNTReviewDisplayLogicTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionControllerTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m WatchTransferStatusTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme2to3MigrationTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeControllerTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporterTests.swift[0m
+[14:53:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskPaperExporterTests.swift[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindJetImporterTests.swift[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentOpenPerformanceTests.swift[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownImporterTests.swift[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontExtractorTests.swift[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCBoundaryMorphTests.swift[0m
+[14:53:54]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[14:53:54]: ▸ [35mlet polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }[0m
+[14:53:54]: ▸ [35m[36m              ^~~~~~~[0m
+[14:53:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasControllerTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleDocument1To2MigrationTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentVersionDecisionTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporterTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextBundleImporterTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNImage+ImageDiff.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCThemeManagerTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLImporterTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m WatchDocumentExporterTests.swift[0m
+[14:53:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskControllerTests.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCInsertPositionCalculatorTests.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m XCTestCase+DocumentHelper.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardTests.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCAccessibilityTextExporterTests.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeTokenStoreTests.swift[0m
+[14:53:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskPaperImporterTests.swift[0m
+[14:54:00]: [35m[33m▸[0m [39;1mCompiling[0m MNTextTests.m[0m
+[14:54:02]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:54:03]: [35m[33m▸[0m [39;1mGenerating 'MindNode\ for\ iOS\ Tests.xctest.dSYM'[0m
+[14:54:03]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm[0m
+[14:54:03]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm[0m
+[14:54:03]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m WatchModel.plist[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode[0m
+[14:54:04]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[14:54:04]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[14:54:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ iOS\ Tests.xctest[0m
+[14:54:05]: [35m[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/PlugIns/MindNode\ for\ iOS\ Tests.xctest[0m
+[14:54:11]: ▸ [35m[39;1mSelected tests[0m
+[14:54:11]: ▸ [35mTest Suite [39;1mPurchasing Tests iOS.xctest[0m started[0m
+[14:54:11]: ▸ [35m[39;1mCurrentReceiptParsingTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testiOSReceiptValidation ([33m0.040[0m seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testMacOSReceiptValidation (0.007 seconds)[0m
+[14:54:11]: ▸ [35m[39;1mLicenseValidatorTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testBrokenLicenseData (0.006 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testBrokenSignedLicenseData (0.001 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testEmtpyData (0.001 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testMissingData (0.001 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testParsingSignedLicense1 (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSignedLicense (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSignedLicenseWithTrial (0.003 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicense (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicenseWithTrial (0.003 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSkippingCertificate (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testValidatingSkippingDeviceIdentifier (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testWrongCertificate (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifier (0.006 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifierAndCertificate (0.003 seconds)[0m
+[14:54:11]: ▸ [35m[39;1mPromotedVisibilityUpdaterTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testCatalogNeeded (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testDoubleUpdateProtection (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testInitialVisibilityUpdates (0.001 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testOverriddenUpdating (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testVisibiliesForFullVersion (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testVisibiliesFromTrial (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testVisibilitiesForPendingDecision (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[39;1mPurchaseServiceDataStoreTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testPersistence (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testUpdateMethods (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[39;1mPurchaseServiceTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testActiveTrialLicenseTrumpsViewerOnly (0.010 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testAdditionalAvailableDiscountedProductOverrulesReceipt (0.006 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testFromExpiredIAPTrialToViewerOnly (0.007 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testFromIAPTrialToViewerOnly (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testFullPurchase (0.008 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testFullPurchaseFromTrialLicense (0.008 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testIAPTrialExpiry (0.021 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testIAPTrialVsLongerTrialLicense (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testIAPTrialVsShorterTrialLicense (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testLicenseTrialExpiry (0.023 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithExistingLicense (0.010 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithoutExistingLicense (0.008 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testPurchaseServiceInvalidReceiptData (0.006 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testReceiptOverrulesAdditionalAvailableDiscountedProduct (0.004 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testStartingTrial (0.007 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testViewerOnlyThenTrialLicenseThenViewerOnly (0.008 seconds)[0m
+[14:54:11]: ▸ [35m[39;1mSignatureVerifierTests[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testCorrectSignatures (0.005 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testMalformedData (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testMalformedSignatureData (0.002 seconds)[0m
+[14:54:11]: ▸ [35m[32;1m✓[0m testMlformedCertificateData (0.002 seconds)[0m
+[14:54:12]: ▸ [35m[33m◷[0m testPerformanceOfSignatureVerification measured (0.000 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testPerformanceOfSignatureVerification ([31m0.545[0m seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testWrongSignatures (0.010 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mUpgradePathAnalysisTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testConcreteiOSUpgradePathAnalysis (0.007 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testConcreteMacOSUpgradePathAnalysis (0.002 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testiOSLegacyReceiptParsing (0.008 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testMacOSLegacyReceiptParsing (0.005 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mVersionNumberTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDigitsAndDotsComparison (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDigitsAndDotsParsing (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDigitsOnly (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDigitsOnlyParsing (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m	 Executed 55 tests, with 0 failures (0 unexpected) in 0.846 (0.914) seconds[0m
+[14:54:12]: ▸ [35m[0m
+[14:54:12]: ▸ [35m[39;1mAll tests[0m
+[14:54:12]: ▸ [35mTest Suite [39;1mShared Tests iOS.xctest[0m started[0m
+[14:54:12]: ▸ [35m[39;1mAppContextInfoTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testFallbacking (0.004 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testNonEmptyCurrentAppContextDeviceInfo (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testNonEmptyCurrentDeviceInfo (0.000 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testUserAgent (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mDefaultTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testBool (0.011 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testData (0.003 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDate (0.002 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testDouble (0.002 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testInt (0.003 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testString (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mErrorComparisonTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testErrorEnumComparison (0.008 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testNSErrorComparison (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mHierarchicalErrorTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testComplexHierarchy (0.002 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testHierarchicalError (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testUnderlyingNetworkError (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mMessageConfigurationTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testActionCount (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testErrorLocalizationWithMessage (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testErrorLocalizationWithMessageCustomActions (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testMessageConfigurationFromLocalizedError (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testMessageConfigurationFromLocalizedErrorWithDescription (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testMessageConfigurationFromLocalizedErrorWithNotMuchAtAll (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testMessageConfigurationFromNSError (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testOKButtonExists (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[39;1mObjCTests[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testContainsObject (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testFastEnumeration (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatAddObjectAddsToWeakArray (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatFirstAndLastObjectReturnCorrectObject (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatFirstAndLastObjectReturnNilForEmptyArray (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatObjectsAreReferencedWeakly (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatRemoveAllObjectsEmptiesWeakArray (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatRemoveObjectCompactsWeakArray (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m✓[0m testThatWeakArrayIsEmpty (0.001 seconds)[0m
+[14:54:12]: ▸ [35m[32;1m	 Executed 32 tests, with 0 failures (0 unexpected) in 0.054 (0.073) seconds[0m
+[14:54:12]: ▸ [35m[0m
+[14:54:24]: ▸ [35m[39;1mAll tests[0m
+[14:54:24]: ▸ [35mTest Suite [39;1mMindNode for iOS Tests.xctest[0m started[0m
+[14:54:24]: ▸ [35m[39;1mMNCAccessibilityTextExporterTests[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testAccessibilityTextExportForCanvasWithSeveralMindMaps ([33m0.026[0m seconds)[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testAccessibilityTextExportForNode (0.005 seconds)[0m
+[14:54:24]: ▸ [35m[39;1mMNCAppLaunchCounterTests[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testMaxAppLaunches (0.015 seconds)[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testShortAppLaunchInterval (0.002 seconds)[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testThatOnly1LaunchPerDayGetsRegistered (0.001 seconds)[0m
+[14:54:24]: ▸ [35m[39;1mMNCCSVExporterTests[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testCounterOfLevels ([31m0.158[0m seconds)[0m
+[14:54:24]: ▸ [35m[32;1m✓[0m testCSV ([31m0.206[0m seconds)[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testCSVisNotEmpty ([31m0.427[0m seconds)[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testHeader ([33m0.098[0m seconds)[0m
+[14:54:25]: ▸ [35m[39;1mMNCCSVImporterTests[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testImport ([31m0.560[0m seconds)[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testMainNodes ([33m0.062[0m seconds)[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testStructure ([33m0.064[0m seconds)[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testTotalNodes ([33m0.065[0m seconds)[0m
+[14:54:25]: ▸ [35m[39;1mMNCCanvasControllerTests[0m
+[14:54:25]: ▸ [35m[32;1m✓[0m testCanvasControllerSetup ([33m0.031[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testInsertParentNode ([31m0.137[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRemoveAllNodes ([33m0.030[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRemoveNode ([33m0.032[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRemoveNodeAndSubnodes ([33m0.030[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRepresentedObject ([33m0.035[0m seconds)[0m
+[14:54:26]: ▸ [35m[39;1mMNCCanvasSelectionControllerTests[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testCanvasSelectionConvenienceGetters (0.005 seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testCanvasSelectionEqualsSelectionController (0.003 seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testCanvasSelectionGetsResetAfterSelectionChange (0.003 seconds)[0m
+[14:54:26]: ▸ [35m[39;1mMNCCanvasTests[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testAddNode (0.001 seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRemoveAllNodes (0.001 seconds)[0m
+[14:54:26]: ▸ [35m[39;1mMNCCollisionControllerTests[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testBoundsCollision ([31m0.145[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testMindMapControllerSelectionMovement ([31m0.191[0m seconds)[0m
+[14:54:26]: ▸ [35m[32;1m✓[0m testRectHitTest ([31m0.113[0m seconds)[0m
+[14:54:26]: ▸ [35m[39;1mMNCDocument4to5MigrationControllerTests[0m
+[14:54:27]: ▸ [35m[32;1m✓[0m testMigration ([31m1.080[0m seconds)[0m
+[14:54:27]: ▸ [35m[32;1m✓[0m testTextMigration ([31m0.102[0m seconds)[0m
+[14:54:27]: ▸ [35m[39;1mMNCDocument5to6MigrationControllerTests[0m
+[14:54:27]: ▸ [35m[32;1m✓[0m testMigration ([33m0.034[0m seconds)[0m
+[14:54:27]: ▸ [35m[39;1mMNCDocumentKVOControllerTests[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testNearestMindMapObject ([31m0.123[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault ([31m0.102[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft ([33m0.093[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleDefault ([33m0.092[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleLeft ([33m0.090[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleManual ([33m0.093[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleRight ([33m0.091[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault ([33m0.092[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight ([33m0.094[0m seconds)[0m
+[14:54:28]: ▸ [35m[32;1m✓[0m testSortingTaskStateRightAligned ([33m0.081[0m seconds)[0m
+[14:54:28]: ▸ [35m[39;1mMNCDocumentOpenPerformanceTests[0m
+[14:54:48]: ▸ [35m[33m◷[0m testLargeMindMapWithTasks measured ([31m1.689[0m seconds)[0m
+[14:54:48]: ▸ [35m[32;1m✓[0m testLargeMindMapWithTasks ([31m19.159[0m seconds)[0m
+[14:55:19]: ▸ [35m[33m◷[0m testMindMapWithLotsOfCrossConnections measured ([31m3.101[0m seconds)[0m
+[14:55:19]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfCrossConnections ([31m31.265[0m seconds)[0m
+[14:56:12]: ▸ [35m[33m◷[0m testMindMapWithLotsOfNodes measured ([31m5.284[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfNodes ([31m53.095[0m seconds)[0m
+[14:56:12]: ▸ [35m[39;1mMNCDocumentTests[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenDocumentWithUnsupportedVersionNumbers ([33m0.035[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion4 ([33m0.097[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion5 ([33m0.098[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion6 ([31m0.103[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpeningEmptyDocument ([33m0.064[0m seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenMindNodeTouchDocument ([33m0.040[0m seconds)[0m
+[14:56:12]: ▸ [35m[39;1mMNCDocumentVersionDecisionTests[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testExport (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testNewDocument (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testOpenDocument (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[39;1mMNCFontExtractorTests[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testCompoundEmoji (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testEmoji (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testEmptyString (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testFontStyle (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testFullyEmojiString (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testFullySymbolic (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testFullySymbolicAndEmojiString (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testNormalFont (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testSymbol (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testSymbolAndEmoji (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[39;1mMNCFontManagerTests[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion1 (0.003 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion10 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion100 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion11 (0.003 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion12 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion13 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion14 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion15 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion16 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion17 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion18 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion19 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion2 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion20 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion21 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion22 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion23 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion24 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion25 (0.003 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion26 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion27 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion28 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion29 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion3 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion30 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion31 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion32 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion33 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion34 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion35 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion36 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion37 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion38 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion39 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion4 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion40 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion41 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion42 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion43 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion44 (0.003 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion45 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion46 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion47 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion48 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion49 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion5 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion50 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion51 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion52 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion53 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion54 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion55 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion56 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion57 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion58 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion59 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion6 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion60 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion61 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion62 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion63 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion64 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion65 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion66 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion67 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion68 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion69 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion7 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion70 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion71 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion72 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion73 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion74 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion75 (0.002 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion76 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion77 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion78 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion79 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion8 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion80 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion81 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion82 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion83 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion84 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion85 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion86 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion87 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion88 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion89 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion9 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion90 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion91 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion92 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion93 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion94 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion95 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion96 (0.001 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion97 (0.000 seconds)[0m
+[14:56:12]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion98 (0.000 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion99 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily1 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily2 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily3 (0.000 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily4 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily5 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily6 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily1 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily10 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily11 (0.000 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily12 (0.002 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily13 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily14 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily2 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily3 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily4 (0.000 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily5 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily6 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily7 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily8 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily9 (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[39;1mMNCFontStyleTests[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testAttributedStringInit (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testNilInit (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testNodeRewire ([31m0.101[0m seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testNormalInit (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testSymbolCharacter (0.001 seconds)[0m
+[14:56:13]: ▸ [35m[39;1mMNCFreeMindImporterTests[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testBranchWidth ([31m0.309[0m seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testBubbleShape ([31m0.205[0m seconds)[0m
+[14:56:13]: ▸ [35m[32;1m✓[0m testCustomTitleColor ([31m0.202[0m seconds)[0m
+[14:56:14]: ▸ [35m[32;1m✓[0m testImport ([31m0.205[0m seconds)[0m
+[14:56:14]: ▸ [35m[32;1m✓[0m testLinks ([31m0.204[0m seconds)[0m
+[14:56:14]: ▸ [35m[32;1m✓[0m testMainNodeHasPillShape ([31m0.203[0m seconds)[0m
+[14:56:14]: ▸ [35m[32;1m✓[0m testNodeAlignment ([31m0.208[0m seconds)[0m
+[14:56:14]: ▸ [35m[32;1m✓[0m testNodeAttributedTitle ([31m0.204[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testNodeTitle ([31m0.202[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.211[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testParsesBranchColor ([31m0.205[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testShapeFillColor ([31m0.199[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testSpecialCharactersDecoding ([33m0.053[0m seconds)[0m
+[14:56:15]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreConnectingCorrectNodes ([31m0.205[0m seconds)[0m
+[14:56:16]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreImported ([31m0.203[0m seconds)[0m
+[14:56:16]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsHaveCorrectColor ([31m0.204[0m seconds)[0m
+[14:56:16]: ▸ [35m[32;1m✓[0m testThatFoldingIsRespected ([31m0.204[0m seconds)[0m
+[14:56:16]: ▸ [35m[32;1m✓[0m testThatFontNamesAreParsed ([31m0.199[0m seconds)[0m
+[14:56:16]: ▸ [35m[32;1m✓[0m testThatFontSizesAreParsed ([31m0.204[0m seconds)[0m
+[14:56:17]: ▸ [35m[32;1m✓[0m testThatNodesDeriveBubbleStyleFromParent ([31m0.205[0m seconds)[0m
+[14:56:17]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleCanOverrideFillColor ([31m0.204[0m seconds)[0m
+[14:56:17]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleDoesntHaveDerivedFillColor ([31m0.204[0m seconds)[0m
+[14:56:17]: ▸ [35m[32;1m✓[0m testThatNotesAreImported ([31m0.409[0m seconds)[0m
+[14:56:18]: ▸ [35m[32;1m✓[0m testThatParsesForkStyle ([31m0.208[0m seconds)[0m
+[14:56:18]: ▸ [35m[39;1mMNCFunctionsTests[0m
+[14:56:18]: ▸ [35m[32;1m✓[0m testCGFloatEquality (0.001 seconds)[0m
+[14:56:18]: ▸ [35m[32;1m✓[0m testStringByRemovingCharactersInSet (0.001 seconds)[0m
+[14:56:18]: ▸ [35m[39;1mMNCHelloPayloadBuilderTests[0m
+[14:56:18]: ▸ [35m[32;1m✓[0m testPayloadConstruction (0.004 seconds)[0m
+[14:56:18]: ▸ [35m[39;1mMNCImageExporterTests[0m
+[14:56:21]: ▸ [35m[32;1m✓[0m testImageRepresentation ([31m2.908[0m seconds)[0m
+[14:56:24]: ▸ [35m[32;1m✓[0m testImageRepresentationWithoutBackground ([31m3.379[0m seconds)[0m
+[14:56:27]: ▸ [35m[32;1m✓[0m testImageRepresentationWithPadding ([31m2.677[0m seconds)[0m
+[14:56:37]: ▸ [35m[32;1m✓[0m testImageRepresentationWithScaling ([31m9.974[0m seconds)[0m
+[14:56:37]: ▸ [35m[39;1mMNCInsertPositionCalculatorTests[0m
+[14:56:37]: ▸ [35m[32;1m✓[0m testInsertionOfSiblingsAboveAndBelow (0.003 seconds)[0m
+[14:56:37]: ▸ [35m[32;1m✓[0m testInsertPositionForManualLeftRightLayout (0.003 seconds)[0m
+[14:56:37]: ▸ [35m[32;1m✓[0m testInsertPositionForTopDownLayout (0.002 seconds)[0m
+[14:56:37]: ▸ [35m[39;1mMNCLayoutCalculatorTests[0m
+[14:56:37]: ▸ [35m[32;1m✓[0m testHorizontalLayout (0.003 seconds)[0m
+[14:56:38]: ▸ [35m[33m◷[0m testHorizontalLayoutCalculationPerformance measured (0.016 seconds)[0m
+[14:56:39]: ▸ [35m[32;1m✓[0m testHorizontalLayoutCalculationPerformance ([31m2.029[0m seconds)[0m
+[14:56:39]: ▸ [35m[32;1m✓[0m testLayoutForLargeSupernodes (0.002 seconds)[0m
+[14:56:39]: ▸ [35m[32;1m✓[0m testVerticalLayout (0.003 seconds)[0m
+[14:56:40]: ▸ [35m[33m◷[0m testVerticalLayoutCalculationPerformance measured (0.016 seconds)[0m
+[14:56:41]: ▸ [35m[32;1m✓[0m testVerticalLayoutCalculationPerformance ([31m2.060[0m seconds)[0m
+[14:56:41]: ▸ [35m[39;1mMNCLayoutControllerTests[0m
+[14:56:41]: ▸ [35m[32;1m✓[0m testDefaultLayoutControllerDeterminism ([33m0.089[0m seconds)[0m
+[14:56:41]: ▸ [35m[32;1m✓[0m testLayoutStyleChange0 ([31m0.180[0m seconds)[0m
+[14:56:41]: ▸ [35m[32;1m✓[0m testLayoutStyleChange1 ([31m0.182[0m seconds)[0m
+[14:56:41]: ▸ [35m[32;1m✓[0m testLayoutStyleChange2 ([31m0.188[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testLayoutStyleChange3 ([31m0.183[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testLayoutStyleChange4 ([31m0.193[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testLayoutStyleChange5 ([31m0.205[0m seconds)[0m
+[14:56:42]: ▸ [35m[39;1mMNCMarkdownExporterTests[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testMarkdownExportWithImages ([31m0.154[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testMarkdownExportWithoutImages ([31m0.153[0m seconds)[0m
+[14:56:42]: ▸ [35m[39;1mMNCMarkdownImporterTests[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testContent ([33m0.050[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([31m0.109[0m seconds)[0m
+[14:56:42]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.033[0m seconds)[0m
+[14:56:43]: ▸ [35m[32;1m✓[0m testStructure ([33m0.033[0m seconds)[0m
+[14:56:43]: ▸ [35m[32;1m✓[0m testTodos ([33m0.034[0m seconds)[0m
+[14:56:43]: ▸ [35m[39;1mMNCMindJetImporterTests[0m
+[14:56:43]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.243[0m seconds)[0m
+[14:56:43]: ▸ [35m[32;1m✓[0m testExportedBackgroundColor ([31m0.474[0m seconds)[0m
+[14:56:44]: ▸ [35m[32;1m✓[0m testExportedNodeTextFormatting ([31m0.487[0m seconds)[0m
+[14:56:44]: ▸ [35m[32;1m✓[0m testHyperlinks ([31m0.230[0m seconds)[0m
+[14:56:44]: ▸ [35m[32;1m✓[0m testImages ([31m0.232[0m seconds)[0m
+[14:56:44]: ▸ [35m[32;1m✓[0m testImport ([31m0.235[0m seconds)[0m
+[14:56:45]: ▸ [35m[32;1m✓[0m testNodeAlignment ([31m0.236[0m seconds)[0m
+[14:56:45]: ▸ [35m[32;1m✓[0m testNodeFormatting ([31m0.232[0m seconds)[0m
+[14:56:45]: ▸ [35m[32;1m✓[0m testNodeText ([31m0.229[0m seconds)[0m
+[14:56:45]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([31m0.226[0m seconds)[0m
+[14:56:46]: ▸ [35m[32;1m✓[0m testNotes ([31m0.228[0m seconds)[0m
+[14:56:46]: ▸ [35m[32;1m✓[0m testNotesAndHyperlinkOnSameNode ([31m0.226[0m seconds)[0m
+[14:56:46]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.231[0m seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testTaskStatus ([31m0.481[0m seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCMindMapTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testImportWithInvalidLayoutStyle (0.001 seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCMyMindNodeTokenStoreTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testMyMindNodeKeyRetrieval (0.001 seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testTokenStoring (0.001 seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCNodeControllerTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testParsingOfNodeDataFromTitle (0.003 seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCNodeHierarchyTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testEmptyNodeHierarchy (0.001 seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testManualNodeHierarchy (0.001 seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testNodeHierarchyOfOpenedDocument ([31m0.202[0m seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testNodeRewire ([31m0.215[0m seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testNodeRewireWith2MindMaps ([31m0.178[0m seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCNodeLayoutCalculatorTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testNodeLayoutCalculation (0.002 seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCOPMLImporterTests[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.032[0m seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testSpecialSingleChildCase (0.015 seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testStructure ([33m0.030[0m seconds)[0m
+[14:56:47]: ▸ [35m[32;1m✓[0m testTasks ([33m0.031[0m seconds)[0m
+[14:56:47]: ▸ [35m[39;1mMNCPasteboardTests[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testCanvasObjectPasteboardParserRoundTrip ([31m0.265[0m seconds)[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testEmptyPasteboard (0.012 seconds)[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testPasteboardCanvasObject ([33m0.046[0m seconds)[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testPasteboardController ([31m0.620[0m seconds)[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testPasteboardEmptyString (0.018 seconds)[0m
+[14:56:48]: ▸ [35m[32;1m✓[0m testPasteboardImage ([31m0.163[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testPasteboardString ([31m0.195[0m seconds)[0m
+[14:56:49]: ▸ [35m[39;1mMNCSetSynchronizerTests[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testInitialSyncMerging (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurAddition (0.000 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurAdditionTheirAddition (0.000 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurAdditionTheirRemoval (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurRemoval (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurRemovalTheirAddition (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testOurRemovalTheirRemoval (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testSyncFailureRollback (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testThatInvalidStateExceptionIsThrown (0.000 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testTheirAddition (0.001 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testTheirRemoval (0.000 seconds)[0m
+[14:56:49]: ▸ [35m[39;1mMNCSpotlightImporterTests[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV4SpotlightIndexerForValidDocument (0.005 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForBigDocument ([33m0.063[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForEmptyDocument (0.005 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForValidDocument (0.007 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithCrossConnectionTitle (0.005 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithNotes (0.005 seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testV6SpotlightIndexer (0.006 seconds)[0m
+[14:56:49]: ▸ [35m[39;1mMNCStyleDocument1to2MigrationTests[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testThatStyleDocumentUpgradeAndDowngradeResultsInOriginalStyleDocument (0.009 seconds)[0m
+[14:56:49]: ▸ [35m[39;1mMNCStyleProxyTests[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testBoxing ([33m0.066[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testKeyPathAccess ([33m0.064[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testStyleProxyObjectUpdate ([33m0.068[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testTextManipulation ([33m0.072[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testTextSpecialCase ([33m0.074[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testThatRemovingLastObjectResultsInEmptyStyleProxy ([33m0.062[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testThatRemovingOfValuesResultsInCorrectStyleValue ([33m0.067[0m seconds)[0m
+[14:56:49]: ▸ [35m[32;1m✓[0m testValueTransformer ([33m0.068[0m seconds)[0m
+[14:56:49]: ▸ [35m[39;1mMNCTaskControllerTest[0m
+[14:56:56]: ▸ [35m[33m◷[0m testActivatingDeactivatingTaskStatePerformance measured ([31m0.583[0m seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testActivatingDeactivatingTaskStatePerformance ([31m7.866[0m seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testMultipleTaskSettingOnDeepTree (0.002 seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testProgressCalculationOnDeepTree (0.002 seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testProgressCalculationOnFlatTree (0.001 seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnDeepTree (0.003 seconds)[0m
+[14:56:57]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnFlatTree (0.001 seconds)[0m
+[14:56:59]: ▸ [35m[33m◷[0m testRefreshPerformance measured ([33m0.033[0m seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testRefreshPerformance ([31m2.272[0m seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testShowTaskControlOnFlatTree (0.002 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTaskCreationViaTitle (0.004 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTaskPropagationOnDeepTree (0.002 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTaskPropagationOnFlatTree (0.002 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTogglingNodeStatesOnFlatTree (0.002 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTogglingOfCompletionStateOnDeepTree (0.002 seconds)[0m
+[14:56:59]: ▸ [35m[32;1m✓[0m testTogglingOfTaskStatesOnDeepTree (0.002 seconds)[0m
+[14:57:03]: ▸ [35m[33m◷[0m testTogglingTaskStatePerformance measured ([31m0.256[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testTogglingTaskStatePerformance ([31m4.543[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testUndoTaskToggleOnDeepTree (0.003 seconds)[0m
+[14:57:04]: ▸ [35m[39;1mMNCTaskPaperExporterTests[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testTaskPaperExport ([31m0.108[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testTaskPaperExportWithOmniFocusConfiguration ([31m0.104[0m seconds)[0m
+[14:57:04]: ▸ [35m[39;1mMNCTaskPaperImporterTests[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testInlineTags ([33m0.033[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testNotes ([33m0.031[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.032[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testStructure ([33m0.036[0m seconds)[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testTasks ([33m0.032[0m seconds)[0m
+[14:57:04]: ▸ [35m[39;1mMNCTextBundleExporterTests[0m
+[14:57:04]: ▸ [35m[32;1m✓[0m testBundleContent ([31m0.154[0m seconds)[0m
+[14:57:05]: ▸ [35m[39;1mMNCTextBundleImporterTests[0m
+[14:57:05]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([31m0.472[0m seconds)[0m
+[14:57:05]: ▸ [35m[32;1m✓[0m testImportOfTextBundleFile ([31m0.121[0m seconds)[0m
+[14:57:05]: ▸ [35m[39;1mMNCTextExporterTests[0m
+[14:57:05]: ▸ [35m[32;1m✓[0m testNodeOrderOfPlainTextExport ([31m0.202[0m seconds)[0m
+[14:57:05]: ▸ [35m[39;1mMNCTextOutlineImporterTests[0m
+[14:57:06]: ▸ [35m[31m✗[0m testPasteboard, failed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x60000184dfb0> was mutated while being enumerated."[0m
+[14:57:06]: ▸ [35m[32;1m✓[0m testPlainTextImport ([31m0.688[0m seconds)[0m
+[14:57:06]: ▸ [35m[39;1mMNCTheme2to3MigrationTests[0m
+[14:57:06]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithColor (0.011 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithNode (0.011 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testThatThemeUpgradeAndDowngradeResultsInOriginalTheme (0.016 seconds)[0m
+[14:57:07]: ▸ [35m[39;1mMNCThemeDataSourceTests[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testThemeOrder (0.005 seconds)[0m
+[14:57:07]: ▸ [35m[39;1mMNCThemeManagerTests[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testAddTheme (0.023 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testRemoveTheme (0.022 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testStandardThemes (0.001 seconds)[0m
+[14:57:07]: ▸ [35m[39;1mMNCThingsExporterTests[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testExportURLGenertion ([31m0.156[0m seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testJSONDataExport ([31m0.154[0m seconds)[0m
+[14:57:07]: ▸ [35m[39;1mMNCUserIntentValidatorTests[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testArrowKeyCommands (0.011 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testAttachmentIntents ([31m0.186[0m seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testBalanceIntents (0.017 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testBeginTextEditingOfConnectionIntent (0.013 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCenterMainNodeIntent (0.003 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testChangeNodeOrderArrowKeyCommands (0.012 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCommitUnwiredConnectionIntent (0.004 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCopyIntent (0.007 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCreateConnectionIntent (0.009 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCreateNewNodeIntents ([33m0.074[0m seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCycleBackwardIntent (0.003 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testCycleForwardIntent (0.003 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testDeleteIntent (0.004 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testDetachNodeIntent (0.018 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testDuplicateIntent (0.008 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testEditNotesIntent (0.012 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testExitDocumentIntent (0.012 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testFoldIntent (0.009 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testFontIntents ([33m0.029[0m seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testFullscreenIntent (0.009 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testMoveNodeArrowKeyCommands (0.007 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testNewMainNodeIntent (0.006 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testNewParentNodeIntent (0.025 seconds)[0m
+[14:57:07]: ▸ [35m[32;1m✓[0m testNodeTextEditing (0.013 seconds)[0m
+[14:57:08]: ▸ [35m[32;1m✓[0m testOpenLinkIntent ([31m1.068[0m seconds)[0m
+[14:57:08]: ▸ [35m[32;1m✓[0m testPanIntents (0.006 seconds)[0m
+[14:57:08]: ▸ [35m[32;1m✓[0m testPasteIntent (0.009 seconds)[0m
+[14:57:08]: ▸ [35m[32;1m✓[0m testPrinterOptionsIntent (0.007 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testRedoIntent (0.012 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testReorganizeNodesIntent (0.009 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testResetCrossConnectionWaypointIntent (0.012 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testResetSelectionModeIntent (0.006 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testSharingIntent (0.007 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testShowInspectorIntents (0.020 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testShowIntents (0.021 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testShowLinkInputPanelIntent (0.006 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testSimpleNodesIntents (0.012 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testSingleObjectIntents (0.009 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testSortNodesAlphabeticallyIntent (0.014 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testSortNodesByTaskStateIntent (0.011 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testStyleIntents (0.008 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testToggleIntents (0.006 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testUndoIntent (0.015 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testUnfolAllNodesIntent (0.009 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testUnfoldOneLevel (0.014 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testZoomInIntent (0.003 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testZoomOutIntent (0.003 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testZoomToActualSizeIntent (0.006 seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testZoomToFitIntent (0.003 seconds)[0m
+[14:57:09]: ▸ [35m[39;1mMNCXMindImporterTests[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testBackgroundColor ([31m0.167[0m seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testContent ([31m0.149[0m seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.149[0m seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testLinks ([31m0.148[0m seconds)[0m
+[14:57:09]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.149[0m seconds)[0m
+[14:57:10]: ▸ [35m[32;1m✓[0m testStructure ([31m0.147[0m seconds)[0m
+[14:57:10]: ▸ [35m[39;1mMNCXMindStyleImporterTest[0m
+[14:57:10]: ▸ [35m[32;1m✓[0m testBorder ([31m0.482[0m seconds)[0m
+[14:57:11]: ▸ [35m[32;1m✓[0m testBorderLineWidth ([31m0.477[0m seconds)[0m
+[14:57:11]: ▸ [35m[32;1m✓[0m testColor ([31m0.487[0m seconds)[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testCrossConnectionStyle ([31m0.466[0m seconds)[0m
+[14:57:12]: ▸ [35m[39;1mMNCZoomingCalculatorTests[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testCalculatorZoomIn (0.001 seconds)[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testCalculatorZoomOut (0.000 seconds)[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testCalculatorZoomScaleEqual (0.000 seconds)[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testDifferentInsets (0.000 seconds)[0m
+[14:57:12]: ▸ [35m[39;1mMNCiThoughtsImporterTests[0m
+[14:57:12]: ▸ [35m[32;1m✓[0m testBoundariesV4 ([31m0.240[0m seconds)[0m
+[14:57:13]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.828[0m seconds)[0m
+[14:57:13]: ▸ [35m[32;1m✓[0m testCrossConnectionsV3 ([31m0.193[0m seconds)[0m
+[14:57:13]: ▸ [35m[32;1m✓[0m testCrossConnectionsV4 ([31m0.231[0m seconds)[0m
+[14:57:14]: ▸ [35m[32;1m✓[0m testHyperlinks ([31m0.845[0m seconds)[0m
+[14:57:14]: ▸ [35m[32;1m✓[0m testHyperlinksV3 ([31m0.198[0m seconds)[0m
+[14:57:14]: ▸ [35m[32;1m✓[0m testHyperlinksV4 ([31m0.233[0m seconds)[0m
+[14:57:15]: ▸ [35m[32;1m✓[0m testImport ([31m0.841[0m seconds)[0m
+[14:57:15]: ▸ [35m[32;1m✓[0m testImportV3 ([31m0.195[0m seconds)[0m
+[14:57:16]: ▸ [35m[32;1m✓[0m testImportV4 ([31m0.227[0m seconds)[0m
+[14:57:16]: ▸ [35m[32;1m✓[0m testLayoutStyle ([31m0.831[0m seconds)[0m
+[14:57:17]: ▸ [35m[32;1m✓[0m testLayoutStyleV3 ([31m0.847[0m seconds)[0m
+[14:57:17]: ▸ [35m[32;1m✓[0m testLineTypeV4 ([31m0.226[0m seconds)[0m
+[14:57:18]: ▸ [35m[32;1m✓[0m testNodeAlignment ([31m0.835[0m seconds)[0m
+[14:57:19]: ▸ [35m[32;1m✓[0m testNodeAlignmentV3 ([31m0.197[0m seconds)[0m
+[14:57:19]: ▸ [35m[32;1m✓[0m testNodeAlignmentV4 ([31m0.231[0m seconds)[0m
+[14:57:20]: ▸ [35m[32;1m✓[0m testNodeFormatting ([31m0.828[0m seconds)[0m
+[14:57:20]: ▸ [35m[32;1m✓[0m testNodeFormattingV3 ([31m0.192[0m seconds)[0m
+[14:57:20]: ▸ [35m[32;1m✓[0m testNodeFormattingV4 ([31m0.227[0m seconds)[0m
+[14:57:21]: ▸ [35m[32;1m✓[0m testNodeText ([31m0.895[0m seconds)[0m
+[14:57:22]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([31m0.869[0m seconds)[0m
+[14:57:22]: ▸ [35m[32;1m✓[0m testNodeTextV3 ([31m0.199[0m seconds)[0m
+[14:57:22]: ▸ [35m[32;1m✓[0m testNodeTextV4 ([31m0.228[0m seconds)[0m
+[14:57:23]: ▸ [35m[32;1m✓[0m testNotes ([31m0.822[0m seconds)[0m
+[14:57:24]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.836[0m seconds)[0m
+[14:57:24]: ▸ [35m[32;1m✓[0m testNumberOfNodesV3 ([31m0.200[0m seconds)[0m
+[14:57:24]: ▸ [35m[32;1m✓[0m testNumberOfNodesV4 ([31m0.231[0m seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testTasks ([31m0.864[0m seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMNColorTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testBlackWhiteComplementColor (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testColorComponentRetrieval (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testDarkenedColor (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testDerivedColor (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testLightenedColor (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testPropertyRepInit (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testRGBComplementColor (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testWebColorString3Init (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testWebColorString6Init (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testWebColorString8Init (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMNTDocumentControllerTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testCreateNewDocument (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testCreateNewDocumentInFolder (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testCreateNewDocumentInFolderWithInvalidName (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testRenameDocument (0.000 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testURLCreation (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMNTRecentDocumentControllerTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testDelegateCalls (0.012 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testEqualURLs (0.008 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testNumberOfDocumentsToTrack (0.017 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testPersistence (0.010 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testRemoval (0.005 seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMNTReviewDisplayLogicTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testFailureAppNotBought ([33m0.029[0m seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testFailureNotEnoughDocuments (0.007 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testFailureNotEnoughtAppLaunches (0.025 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testSucess ([33m0.027[0m seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMNTextTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testApplyStyle (0.004 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testApplyStyleInRange (0.002 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testEditing (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testEmptyInit (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testFindString (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testInit (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testSavingAndLoadingOfStringWithSpecialControlCharacters (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testSetString (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testTextWithAttributes (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testTextWithFont (0.001 seconds)[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testTextWithFontMonospaced (0.003 seconds)[0m
+[14:57:25]: ▸ [35m[39;1mMorphingTests[0m
+[14:57:25]: ▸ [35m[32;1m✓[0m testNormalization (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[33m◷[0m testPerformance measured ([31m0.180[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testPerformance ([31m2.369[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testSimpleInsert (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testSimpleMatch (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testSimpleMorph (0.000 seconds)[0m
+[14:57:28]: ▸ [35m[39;1mNSAttributedStringMarkdownTests[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testBoldItalic (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testBoldMarkdownConversion (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testCombiningAttributes (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testItalicMarkdownConversion (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testLinkConversion (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testParagraphs (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testPlainTextConversion (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testStrikethroughConversion (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[39;1mNSRangeSwiftTests[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testFullRange (0.000 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testSubStringFromIndex (0.001 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testSubStringFromRange (0.000 seconds)[0m
+[14:57:28]: ▸ [35m[39;1mSSWZipTests[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testAddCompressedEntry ([33m0.049[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testAddSymbolicLink ([33m0.026[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testAddUncompressedEntry ([33m0.028[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testCreateCompressedArchive ([33m0.026[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testCreateNestedDirectoryStrucutre (0.023 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testCreateUncompressedArchive (0.023 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testDetectionOfUnspportedFormatFeatures ([33m0.076[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testLastModFileDate ([33m0.032[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testLastModFileTime (0.024 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testNonUnixOSTypes (0.017 seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testPosixPermissions ([33m0.032[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testRemoveCompressedEntry ([33m0.073[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testRemoveUncompressedEntry ([33m0.055[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToData ([33m0.054[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToURL ([33m0.032[0m seconds)[0m
+[14:57:28]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderArchive (0.013 seconds)[0m
+[14:57:29]: ▸ [35m[33m◷[0m testUnzipCompressedFolderEntries measured (0.003 seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderEntries ([31m0.304[0m seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipItemAtURL ([33m0.065[0m seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipItemAtURLErrorConditions (0.013 seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToData ([33m0.049[0m seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToURL ([33m0.034[0m seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderArchive (0.014 seconds)[0m
+[14:57:29]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderEntries ([33m0.040[0m seconds)[0m
+[14:57:32]: ▸ [35m[33m◷[0m testZipDirectoryContentsAtURL measured ([31m0.300[0m seconds)[0m
+[14:57:32]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURL ([31m3.307[0m seconds)[0m
+[14:57:32]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURLErrorConditions (0.014 seconds)[0m
+[14:57:32]: ▸ [35m[39;1mWatchDocumentExporterTests[0m
+[14:57:32]: ▸ [35m[32;1m✓[0m testExample (0.011 seconds)[0m
+[14:57:32]: ▸ [35m[39;1mWatchTransferStatusTests[0m
+[14:57:32]: ▸ [35m[32;1m✓[0m testWatchTransferPersistence (0.003 seconds)[0m
+[14:57:32]: ▸ [35mMindNode_for_iOS_Tests.MNCTextOutlineImporterTests[0m
+[14:57:32]: ▸ [35mtestPasteboard, [31mfailed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x60000184dfb0> was mutated while being enumerated."[0m
+[14:57:32]: ▸ [35m[36m<unknown>:0[0m
+[14:57:32]: ▸ [35m[31m	 Executed 509 tests, with 1 failure (1 unexpected) in 188.178 (188.426) seconds[0m
+[14:57:32]: ▸ [35m[0m
+[14:57:33]: ▸ [35mFailing tests:[0m
+[14:57:33]: ▸ [35mMNCTextOutlineImporterTests.testPasteboard()[0m
+[14:57:33]: ▸ [35m** TEST FAILED **[0m
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ Stickers/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift
+[33m▸[0m [39;1mCompiling[0m MindNode\ Stickers_vers.c
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m MindNode\ Stickers.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex
+[33m▸[0m [39;1mAnalyzing[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c
+[33m▸[0m [39;1mLinking[0m Shared_watchOS
+[33m▸[0m [39;1mTouching[0m Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ Today\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift
+[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m MindNode\ Today\ Extension_vers.c
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist
+[33m▸[0m [39;1mCompiling[0m Mappings.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift
+[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift
+[33m▸[0m [39;1mCompiling[0m FontBuilder.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift
+[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift
+[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Ashton.swift
+[33m▸[0m [39;1mCompiling[0m Ashton_vers.c
+[33m▸[0m [39;1mLinking[0m Ashton
+[33m▸[0m [39;1mCopying[0m Ashton.h
+[33m▸[0m [39;1mTouching[0m Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mAnalyzing[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Platform.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#elseif (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Defaults.swift
+[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift
+[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift
+[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m SupportLink.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift
+[33m▸[0m [39;1mCompiling[0m WeakRef.swift
+[33m▸[0m [39;1mCompiling[0m DebugMenu.swift
+[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNCMirror.m
+[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m
+[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m Shared_vers.c
+[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m
+[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m
+[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mLinking[0m Shared
+[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h
+[33m▸[0m [39;1mCopying[0m MNCWeakArray.h
+[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h
+[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNFunctions.h
+[33m▸[0m [39;1mCopying[0m MNCMirror.h
+[33m▸[0m [39;1mTouching[0m Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info-iOS.plist
+[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift
+[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift
+[33m▸[0m [39;1mCompiling[0m Receipt.swift
+[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift
+[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift
+[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c
+[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mLinking[0m AppReceiptValidator
+[33m▸[0m [39;1mCopying[0m rc4.h
+[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h
+[33m▸[0m [39;1mCopying[0m cms.h
+[33m▸[0m [39;1mCopying[0m dh.h
+[33m▸[0m [39;1mCopying[0m sha.h
+[33m▸[0m [39;1mCopying[0m lhash.h
+[33m▸[0m [39;1mCopying[0m md5.h
+[33m▸[0m [39;1mCopying[0m ebcdic.h
+[33m▸[0m [39;1mCopying[0m ocsp.h
+[33m▸[0m [39;1mCopying[0m pkcs7.h
+[33m▸[0m [39;1mCopying[0m whrlpool.h
+[33m▸[0m [39;1mCopying[0m cmac.h
+[33m▸[0m [39;1mCopying[0m x509v3.h
+[33m▸[0m [39;1mCopying[0m conf.h
+[33m▸[0m [39;1mCopying[0m e_os2.h
+[33m▸[0m [39;1mCopying[0m rand.h
+[33m▸[0m [39;1mCopying[0m evp.h
+[33m▸[0m [39;1mCopying[0m x509.h
+[33m▸[0m [39;1mCopying[0m bio.h
+[33m▸[0m [39;1mCopying[0m mdc2.h
+[33m▸[0m [39;1mCopying[0m stack.h
+[33m▸[0m [39;1mCopying[0m rsa.h
+[33m▸[0m [39;1mCopying[0m opensslv.h
+[33m▸[0m [39;1mCopying[0m asn1t.h
+[33m▸[0m [39;1mCopying[0m objects.h
+[33m▸[0m [39;1mCopying[0m idea.h
+[33m▸[0m [39;1mCopying[0m ecdh.h
+[33m▸[0m [39;1mCopying[0m ecdsa.h
+[33m▸[0m [39;1mCopying[0m opensslconf.h
+[33m▸[0m [39;1mCopying[0m bn.h
+[33m▸[0m [39;1mCopying[0m ripemd.h
+[33m▸[0m [39;1mCopying[0m kssl.h
+[33m▸[0m [39;1mCopying[0m ui_compat.h
+[33m▸[0m [39;1mCopying[0m comp.h
+[33m▸[0m [39;1mCopying[0m krb5_asn.h
+[33m▸[0m [39;1mCopying[0m ec.h
+[33m▸[0m [39;1mCopying[0m x509_vfy.h
+[33m▸[0m [39;1mCopying[0m txt_db.h
+[33m▸[0m [39;1mCopying[0m cast.h
+[33m▸[0m [39;1mCopying[0m des.h
+[33m▸[0m [39;1mCopying[0m ssl2.h
+[33m▸[0m [39;1mCopying[0m pqueue.h
+[33m▸[0m [39;1mCopying[0m symhacks.h
+[33m▸[0m [39;1mCopying[0m srtp.h
+[33m▸[0m [39;1mCopying[0m ssl3.h
+[33m▸[0m [39;1mCopying[0m aes.h
+[33m▸[0m [39;1mCopying[0m dsa.h
+[33m▸[0m [39;1mCopying[0m engine.h
+[33m▸[0m [39;1mCopying[0m md4.h
+[33m▸[0m [39;1mCopying[0m ts.h
+[33m▸[0m [39;1mCopying[0m err.h
+[33m▸[0m [39;1mCopying[0m dso.h
+[33m▸[0m [39;1mCopying[0m rc2.h
+[33m▸[0m [39;1mCopying[0m hmac.h
+[33m▸[0m [39;1mCopying[0m conf_api.h
+[33m▸[0m [39;1mCopying[0m ossl_typ.h
+[33m▸[0m [39;1mCopying[0m crypto.h
+[33m▸[0m [39;1mCopying[0m srp.h
+[33m▸[0m [39;1mCopying[0m des_old.h
+[33m▸[0m [39;1mCopying[0m pem2.h
+[33m▸[0m [39;1mCopying[0m modes.h
+[33m▸[0m [39;1mCopying[0m ui.h
+[33m▸[0m [39;1mCopying[0m camellia.h
+[33m▸[0m [39;1mCopying[0m tls1.h
+[33m▸[0m [39;1mCopying[0m safestack.h
+[33m▸[0m [39;1mCopying[0m seed.h
+[33m▸[0m [39;1mCopying[0m asn1.h
+[33m▸[0m [39;1mCopying[0m blowfish.h
+[33m▸[0m [39;1mCopying[0m pkcs12.h
+[33m▸[0m [39;1mCopying[0m dtls1.h
+[33m▸[0m [39;1mCopying[0m buffer.h
+[33m▸[0m [39;1mCopying[0m pem.h
+[33m▸[0m [39;1mCopying[0m ssl.h
+[33m▸[0m [39;1mCopying[0m ssl23.h
+[33m▸[0m [39;1mCopying[0m obj_mac.h
+[33m▸[0m [39;1mCopying[0m asn1_mac.h
+[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c
+[33m▸[0m [39;1mLinking[0m CommonCrypto
+[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h
+[33m▸[0m [39;1mTouching[0m CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist
+[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift
+[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift
+[33m▸[0m [39;1mCompiling[0m Archive.swift
+[33m▸[0m [39;1mCompiling[0m Data+Compression.swift
+[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+
+let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+[36m                                            ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Entry.swift
+[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift
+[33m▸[0m [39;1mLinking[0m ZIPFoundation
+[33m▸[0m [39;1mTouching[0m ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m
+[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift
+[33m▸[0m [39;1mCompiling[0m WatchNode.swift
+[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift
+[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift
+[33m▸[0m [39;1mCompiling[0m WatchTask.swift
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift
+[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift
+[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift
+[33m▸[0m [39;1mCompiling[0m PropertyReader.swift
+[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNColor+MindNode.swift
+[33m▸[0m [39;1mCompiling[0m ComplicationController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MindNode\ for\ Apple\ Watch\ Extension_vers.c
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mAnalyzing[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImage.m
+[33m▸[0m [39;1mAnalyzing[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m FTAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj
+[33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle
+[33m▸[0m [39;1mAnalyzing[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mCompiling[0m JLRoutes.m
+[33m▸[0m [39;1mAnalyzing[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m JLRoutes.m
+[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m
+[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MBProgressHUD.m
+[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m MNCLogging.m
+[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m
+[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheet.m
+[33m▸[0m [39;1mAnalyzing[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist
+[33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle
+[33m▸[0m [39;1mAnalyzing[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m
+[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m
+[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mAnalyzing[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mAnalyzing[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m RBBAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mAnalyzing[0m RBBCubicBezier.m
+[33m▸[0m [39;1mAnalyzing[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBEasingFunction.m
+[33m▸[0m [39;1mAnalyzing[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mAnalyzing[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgement.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2Body.cpp
+[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mCompiling[0m b2Contact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Collision.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mCompiling[0m b2Distance.cpp
+[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Draw.cpp
+[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp
+[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Island.cpp
+[33m▸[0m [39;1mCompiling[0m b2Joint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Math.cpp
+[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Rope.cpp
+[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Settings.cpp
+[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Timer.cpp
+[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2World.cpp
+[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2World.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mAnalyzing[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m
+[33m▸[0m [39;1mAnalyzing[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m NYTScalingImageView.m
+[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m blocks.c
+[33m▸[0m [39;1mCompiling[0m buffer.c
+[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m cmark.c
+[33m▸[0m [39;1mCompiling[0m cmark_ctype.c
+[33m▸[0m [39;1mCompiling[0m commonmark.c
+[33m▸[0m [39;1mCompiling[0m houdini_href_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_u.c
+[33m▸[0m [39;1mCompiling[0m html.c
+[33m▸[0m [39;1mCompiling[0m inlines.c
+[33m▸[0m [39;1mCompiling[0m iterator.c
+[33m▸[0m [39;1mCompiling[0m latex.c
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m man.c
+[33m▸[0m [39;1mCompiling[0m node.c
+[33m▸[0m [39;1mCompiling[0m references.c
+[33m▸[0m [39;1mCompiling[0m render.c
+[33m▸[0m [39;1mCompiling[0m scanners.c
+[33m▸[0m [39;1mCompiling[0m utf8.c
+[33m▸[0m [39;1mCompiling[0m xml.c
+[33m▸[0m [39;1mAnalyzing[0m blocks.c
+[33m▸[0m [39;1mAnalyzing[0m buffer.c
+[33m▸[0m [39;1mAnalyzing[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m cmark.c
+[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c
+[33m▸[0m [39;1mAnalyzing[0m commonmark.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c
+[33m▸[0m [39;1mAnalyzing[0m html.c
+[33m▸[0m [39;1mAnalyzing[0m inlines.c
+[33m▸[0m [39;1mAnalyzing[0m iterator.c
+[33m▸[0m [39;1mAnalyzing[0m latex.c
+[33m▸[0m [39;1mAnalyzing[0m main.c
+[33m▸[0m [39;1mAnalyzing[0m man.c
+[33m▸[0m [39;1mAnalyzing[0m node.c
+[33m▸[0m [39;1mAnalyzing[0m references.c
+[33m▸[0m [39;1mAnalyzing[0m render.c
+[33m▸[0m [39;1mAnalyzing[0m scanners.c
+[33m▸[0m [39;1mAnalyzing[0m utf8.c
+[33m▸[0m [39;1mAnalyzing[0m xml.c
+[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a
+[33m▸[0m [39;1mAnalyzing[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift
+[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift
+[33m▸[0m [39;1mCompiling[0m PanelView.swift
+[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift
+[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift
+[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m ContainerView.swift
+[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift
+[33m▸[0m [39;1mCompiling[0m SeparatorView.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransition.swift
+[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift
+[33m▸[0m [39;1mCompiling[0m ShadowView.swift
+[33m▸[0m [39;1mCompiling[0m PanelGestures.swift
+[33m▸[0m [39;1mCompiling[0m Panel.swift
+[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c
+[33m▸[0m [39;1mLinking[0m Aiolos
+[33m▸[0m [39;1mCopying[0m Aiolos.h
+[33m▸[0m [39;1mTouching[0m Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertAction.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertLabel.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewController.m
+[33m▸[0m [39;1mAnalyzing[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mAnalyzing[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+Parallax.m
+[33m▸[0m [39;1mAnalyzing[0m UIViewController+Current.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift
+[33m▸[0m [39;1mCompiling[0m TrialState.swift
+[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift
+[33m▸[0m [39;1mCompiling[0m SignedLicense.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift
+[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift
+[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift
+[33m▸[0m [39;1mCompiling[0m License.swift
+[33m▸[0m [39;1mCompiling[0m License+Products.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift
+[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift
+[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift
+[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift
+[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift
+[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift
+[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift
+[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift
+[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService.swift
+[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Then.swift
+[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift
+[33m▸[0m [39;1mCompiling[0m VersionNumber.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift
+[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift
+[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c
+[33m▸[0m [39;1mLinking[0m Purchasing
+[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h
+[33m▸[0m [39;1mTouching[0m Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mAnalyzing[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+
+Done linting! Found 2 violations, 0 serious in 22 files.
+[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ColorDragController.swift
+[33m▸[0m [39;1mCompiling[0m HeaderView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DataStore.swift
+[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift
+[33m▸[0m [39;1mCompiling[0m ColorPalette.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Color.swift
+[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColors.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m ApplyButton.swift
+[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift
+[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c
+[33m▸[0m [39;1mLinking[0m Yellowstone
+[33m▸[0m [39;1mCopying[0m Yellowstone.h
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mTouching[0m Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mAnalyzing[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m Reachability.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#if (arch(i386) || arch(x86_64)) && os(iOS)
+[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Reachability_vers.c
+[33m▸[0m [39;1mLinking[0m Reachability
+[33m▸[0m [39;1mCopying[0m Reachability.h
+[33m▸[0m [39;1mTouching[0m Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS\ Tests-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ iOS\ Tests-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS\ Tests.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS.a
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m Resources/MindNodeTouch-Info.plist
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 540ms to type-check (limit: 500ms)[0m
+
+func updateConstraints(forViewSize size: CGSize) {
+[36m         ^[0m
+
+
+[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MNTCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m
+[33m▸[0m [39;1mCompiling[0m UIFont+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m
+[33m▸[0m [39;1mCompiling[0m UIFontDescriptor+MNTDiscovery.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m
+[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m
+[33m▸[0m [39;1mCompiling[0m MNCPathView.m
+[33m▸[0m [39;1mCompiling[0m NSString+Paths.m
+[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCNode.m
+[33m▸[0m [39;1mCompiling[0m MNTStepperTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumCell.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas.m
+[33m▸[0m [39;1mCompiling[0m MNTKeyboardInformation.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m
+[33m▸[0m [39;1mCompiling[0m MNTTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTFontDownloader.m
+[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeWebViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTColorViewInCell.m
+[33m▸[0m [39;1mCompiling[0m MNCExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalScreenViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeView.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m
+[33m▸[0m [39;1mCompiling[0m MNTOverlayView.m
+[33m▸[0m [39;1mCompiling[0m MNCDevice.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeStyleInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m
+[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTScrollView.m
+[33m▸[0m [39;1mCompiling[0m UIResponder+MNTFirstResponder.m
+[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTColorTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m
+[33m▸[0m [39;1mCompiling[0m MNTFontStyleViewController.m
+[33m▸[0m [39;1mCompiling[0m UICollectionReusableView+MNTReuseIdentifier.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionsBrowserViewController.m
+[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m
+[33m▸[0m [39;1mCompiling[0m MNCContent.m
+[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mCompiling[0m MNTSwitchTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m
+[33m▸[0m [39;1mCompiling[0m UIFont+MNCustomFont.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseViewController.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m
+[33m▸[0m [39;1mCompiling[0m MNTCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNTTextEditor.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentConflictResolutionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m
+[33m▸[0m [39;1mCompiling[0m MNTNavigationControllerTransitionDelegate.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m
+[33m▸[0m [39;1mCompiling[0m main.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m
+[33m▸[0m [39;1mCompiling[0m MNTShareViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeView.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m
+[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCAsset.m
+[33m▸[0m [39;1mCompiling[0m MNVector.m
+[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m
+[33m▸[0m [39;1mCompiling[0m MNTNotesDetailViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m
+[33m▸[0m [39;1mCompiling[0m MNTCrossConnectionInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTExportController.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionNode.m
+[33m▸[0m [39;1mCompiling[0m MNTQuickLookPhoto.m
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegistrationViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTLoadingIndicatorCell.m
+[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineSearchCell.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m UIButton+MNLongPress.m
+[33m▸[0m [39;1mCompiling[0m MNError.m
+[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTArrowTypeCell.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerManager.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionBorder.m
+[33m▸[0m [39;1mCompiling[0m MNTAppearance.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentPrinter.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionCrossConnection.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m
+[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeURLActivityItemProvider.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m
+[33m▸[0m [39;1mCompiling[0m MNTCanvasPrintSinglePageRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m
+[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m
+[33m▸[0m [39;1mCompiling[0m UIView+Animation.m
+[33m▸[0m [39;1mCompiling[0m MNTPathStyleCell.m
+[33m▸[0m [39;1mCompiling[0m MNTClipArtPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentSharableData.m
+[33m▸[0m [39;1mCompiling[0m MNTStepper.m
+[33m▸[0m [39;1mCompiling[0m MNCNote.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleController.m
+[33m▸[0m [39;1mCompiling[0m MNTAccessibilityCustomAction.m
+[33m▸[0m [39;1mCompiling[0m MNTKeyboardAccessory.m
+[33m▸[0m [39;1mCompiling[0m UIImage+MNBlockDrawing.m
+[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionCell.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadProgressViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTWindow.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineBaseCell.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m
+[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCText.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNTPlaceholderTextView.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTTextFormatCell.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionText.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentViewController.m
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/iOS/Sources/Document UI/MNTDocumentViewController.m:2085:9: [33mTODO: don't close if we resolved a conflict, but reload document [-W#pragma-messages][0m
+
+#pragma message("TODO: don't close if we resolved a conflict, but reload document")
+[36m        ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTAccessibilityDefines.m
+[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m
+[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m
+[33m▸[0m [39;1mCompiling[0m MNTDocument.m
+[33m▸[0m [39;1mCompiling[0m MNTTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m UIBarButtonItem+MNLongPress.m
+[33m▸[0m [39;1mCompiling[0m MNTDateFormatter.m
+[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTFontPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNTButtonCell.m
+[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSource.m
+[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArt.m
+[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCTextController.m
+[33m▸[0m [39;1mCompiling[0m MNTCircularProgressView.m
+[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m
+[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNTWebViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNTLightBoxView.m
+[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m
+[33m▸[0m [39;1mCompiling[0m UIMenuController+UserInfo.m
+[33m▸[0m [39;1mCompiling[0m UIApplication+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeTableViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm
+[33m▸[0m [39;1mCompiling[0m MNCFileLink.m
+[33m▸[0m [39;1mCompiling[0m MNTAppDelegate.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerCell.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeShapeTypeCell.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m
+[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineCell.m
+[33m▸[0m [39;1mCompiling[0m MNCSearchableIndex.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNTApplication.m
+[33m▸[0m [39;1mCompiling[0m MNCTask.m
+[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m UIImage+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController+Actions.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTCheckmarkTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTCreditsViewController.m
+[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm
+[33m▸[0m [39;1mCompiling[0m UIImage+TintColor.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalKeyboardManager.m
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m
+[33m▸[0m [39;1mCompiling[0m NSString+UUID.m
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+MNAccessibility.m
+[33m▸[0m [39;1mCompiling[0m MNTCollectionViewHeaderView.m
+[33m▸[0m [39;1mCompiling[0m MNTMindMapLayoutCell.m
+[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m
+[33m▸[0m [39;1mCompiling[0m UIScrollView+Scrolling.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm
+[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m
+[33m▸[0m [39;1mCompiling[0m UISearchBar+MNTCancellation.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m
+[33m▸[0m [39;1mCompiling[0m MNDefaults.m
+[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeSafariActivity.m
+[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetsCollection.m
+[33m▸[0m [39;1mCompiling[0m MNTFontManager.m
+[33m▸[0m [39;1mCompiling[0m MNTFadeTransition.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSourceSection.m
+[33m▸[0m [39;1mCompiling[0m UIView+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+MNTModalSwipeDismiss.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNTCustomFontLabel.m
+[33m▸[0m [39;1mCompiling[0m MNTTextEditorView.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m
+[33m▸[0m [39;1mCompiling[0m SSWZip.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSourceItem.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseTableViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMindNodeExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m UIFont+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCloudShapeGenerator.m
+[33m▸[0m [39;1mAnalyzing[0m UIFontDescriptor+MNTDiscovery.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAssetPickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLayoutManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNExporting.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAnalyticsTracker.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPathView.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+Paths.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNode+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNTStepperTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAlbumCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRemindersSyncController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTKeyboardInformation.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvas.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOPMLExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNImporting.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme+Creation.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineLayouter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTTextFieldTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFontDownloader.m
+[33m▸[0m [39;1mAnalyzing[0m MNTMyMindNodeWebViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTColorViewInCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadFinishedViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineSearchDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNTExternalScreenViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBaseDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAshtonValueTransformer.m
+[33m▸[0m [39;1mAnalyzing[0m NSURL+QueryParsing.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadStartViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNodeView.m
+[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNodeWellButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOverlayView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDevice.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNodeStyleInspectorViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCValueTransformerRegistration.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPlainTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m UIResponder+MNTFirstResponder.m
+[33m▸[0m [39;1mAnalyzing[0m MNCShapeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNTColorTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFontStyleViewController.m
+[33m▸[0m [39;1mAnalyzing[0m UICollectionReusableView+MNTReuseIdentifier.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentVersionsBrowserViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MTDXMLElement.m
+[33m▸[0m [39;1mAnalyzing[0m MNCContent.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+CIELAB.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNTSwitchTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAttachmentRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m UIFont+MNCustomFont.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorBaseViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+Stack.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTTextEditor.m
+[33m▸[0m [39;1mAnalyzing[0m UIViewController+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCachingImageManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBranchRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentConflictResolutionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleValue.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNavigationControllerTransitionDelegate.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAlbumPickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRemindersExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTranslateNodeController.m
+[33m▸[0m [39;1mAnalyzing[0m main.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchToggleButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNTShareViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeView.m
+[33m▸[0m [39;1mAnalyzing[0m NSObject+MNSwizzling.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNCText+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAsset.m
+[33m▸[0m [39;1mAnalyzing[0m MNVector.m
+[33m▸[0m [39;1mAnalyzing[0m MNCUserGuideView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNotesDetailViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCSVParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCrossConnectionInspectorViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTSettingsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTExportController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNTQuickLookPhoto.m
+[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeRegistrationViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTLoadingIndicatorCell.m
+[33m▸[0m [39;1mAnalyzing[0m NSTextAttachment+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineSearchCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerContentDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNTextView+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m UIButton+MNLongPress.m
+[33m▸[0m [39;1mAnalyzing[0m MNError.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPDFExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTArrowTypeCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTExternalCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNMainThreadHangDetector.m
+[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArtAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionBorder.m
+[33m▸[0m [39;1mAnalyzing[0m MNTAppearance.m
+[33m▸[0m [39;1mAnalyzing[0m NSObject+MNCoalescing.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentPrinter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionCrossConnection.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCIThoughtsParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOPMLParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeURLActivityItemProvider.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCanvasPrintSinglePageRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSimpleXMLExporter.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+Animation.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPathStyleCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTClipArtPickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentSharableData.m
+[33m▸[0m [39;1mAnalyzing[0m MNTStepper.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNote.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument4to5MigrationController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTAccessibilityCustomAction.m
+[33m▸[0m [39;1mAnalyzing[0m MNTKeyboardAccessory.m
+[33m▸[0m [39;1mAnalyzing[0m UIImage+MNBlockDrawing.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableAttributedString+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPersistentObjectSavingManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentVersionCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLayoutControllerManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadProgressViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTWindow.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineBaseCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchColorView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineSettingsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMigrationManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxy.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPathStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCText.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPlaceholderTextView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionStyle.m
+[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+ObjectsConvenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNTTextFormatCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorSectionText.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRichTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTAccessibilityDefines.m
+[33m▸[0m [39;1mAnalyzing[0m NSIndexPath+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCUndoManager.m
+[33m▸[0m [39;1mAnalyzing[0m CAAnimation+MNCompletionBlocks.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocument.m
+[33m▸[0m [39;1mAnalyzing[0m MNTTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m UIBarButtonItem+MNLongPress.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDateFormatter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPasteboardController.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFontPickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBranchRepresentedObject.m
+[33m▸[0m [39;1mAnalyzing[0m MNTButtonCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTextOutlineParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NSDateFormatter+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeSettingsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvas+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArt.m
+[33m▸[0m [39;1mAnalyzing[0m MNCResizeKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImageExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTextController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCircularProgressView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPastePersistentManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImageAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m MNTWebViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNTLightBoxView.m
+[33m▸[0m [39;1mAnalyzing[0m NSURL+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m UIMenuController+UserInfo.m
+[33m▸[0m [39;1mAnalyzing[0m UIApplication+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeWellButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCSVExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTContentSizeTableViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPersistentImageManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController+box2dInterface.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFileLink.m
+[33m▸[0m [39;1mAnalyzing[0m MNTAppDelegate.m
+[33m▸[0m [39;1mAnalyzing[0m MNTImagePickerCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeRepresentedObject.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNTNodeShapeTypeCell.m
+[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Components.m
+[33m▸[0m [39;1mAnalyzing[0m NSParagraphStyle+MNConvenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSubselectionResizeKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArtSet.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStrokeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNTOutlineCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSearchableIndex.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTaskSyncController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTApplication.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTask.m
+[33m▸[0m [39;1mAnalyzing[0m NSData+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mAnalyzing[0m UIImage+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInteractionCanvasViewController+Actions.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCheckmarkTableViewCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineTasksDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCreditsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m UIImage+TintColor.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+UUID.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMarkdownExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNTExternalKeyboardManager.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCollectionViewHeaderView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCColorValueTransformer.m
+[33m▸[0m [39;1mAnalyzing[0m UIViewController+MNAccessibility.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFileProgressViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTMindMapLayoutCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCArrowStyle.m
+[33m▸[0m [39;1mAnalyzing[0m UIScrollView+Scrolling.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineNodeCache.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerComposedDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNCConvexHullController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFontStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelectionController.m
+[33m▸[0m [39;1mAnalyzing[0m UISearchBar+MNTCancellation.m
+[33m▸[0m [39;1mAnalyzing[0m MNDefaults.m
+[33m▸[0m [39;1mAnalyzing[0m MNTMyMindNodeSafariActivity.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMindjetParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionView.m
+[33m▸[0m [39;1mAnalyzing[0m MNTPhotoAssetsCollection.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFontManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNTFadeTransition.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController+Selection.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDataSourceSection.m
+[33m▸[0m [39;1mAnalyzing[0m UIView+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelection.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNodeDocument.m
+[33m▸[0m [39;1mAnalyzing[0m UIViewController+MNTModalSwipeDismiss.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme1To2MigrationController.m
+[33m▸[0m [39;1mAnalyzing[0m MNTCustomFontLabel.m
+[33m▸[0m [39;1mAnalyzing[0m MNTTextEditorView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTaskButton.m
+[33m▸[0m [39;1mAnalyzing[0m SSWZip.m
+[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+MNCProperties.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDataSourceItem.m
+[33m▸[0m [39;1mAnalyzing[0m MNTInspectorBaseTableViewController.m
+[33m▸[0m [39;1mLinking[0m MindNode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-acknowledgements.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromo.html
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme
+[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.xib
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoAppIcon.pdf
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme
+[33m▸[0m [39;1mCopying[0m credits.plist
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconMedal.svg
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconDevices.svg
+[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.xib
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer
+[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-metadata.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCompiling[0m MNTLaunchScreen.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Aiolos.framework
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app
+[33m▸[0m [39;1mAnalyzing[0m MindNode for iOS/MindNode for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/iOS/Info.plist
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mCompiling[0m MNTDocumentControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCAppLauncherTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFunctionsTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCollisionControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMindMapTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeLayoutCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCSetSynchronizerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeHierarchyControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCPropertyRepresentationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontManagerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTUserIntentValidatorTests.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:569:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+].flatMap { $0 }
+[36m              ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:645:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+].flatMap { $0 }
+[36m              ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCLayoutCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextOutlineImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCZoomingCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCHelloPayloadBuilderTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeDataSourceTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThingsExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextBundleExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontStyleTests.swift
+[33m▸[0m [39;1mCompiling[0m NSAttributedStringMarkdownTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCXMindImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocument5to6MigrationControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m NSRangeSwiftTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCSVExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCiThoughtsImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNColorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCSVImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTReviewDisplayLogicTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m WatchTransferStatusTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTheme2to3MigrationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskPaperExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMindJetImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentOpenPerformanceTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontExtractorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCBoundaryMorphTests.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }
+[36m              ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCCanvasControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCStyleDocument1To2MigrationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentVersionDecisionTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCImageExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCanvasTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextBundleImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNImage+ImageDiff.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeManagerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCOPMLImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCInsertPositionCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m XCTestCase+DocumentHelper.swift
+[33m▸[0m [39;1mCompiling[0m MNCPasteboardTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskPaperImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeTokenStoreTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCAccessibilityTextExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentControllerTests.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxyTests.m
+[33m▸[0m [39;1mCompiling[0m NSDictionary+MNTestHelper.m
+[33m▸[0m [39;1mCompiling[0m SSWZipTests.m
+[33m▸[0m [39;1mCompiling[0m MNTextTests.m
+[33m▸[0m [39;1mCompiling[0m MindNode\ for\ iOS\ Tests_vers.c
+[33m▸[0m [39;1mAnalyzing[0m MNTRecentDocumentControllerTests.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyTests.m
+[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNTestHelper.m
+[33m▸[0m [39;1mAnalyzing[0m SSWZipTests.m
+[33m▸[0m [39;1mAnalyzing[0m MNTextTests.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mGenerating 'MindNode\ for\ iOS\ Tests.xctest.dSYM'[0m
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode
+[33m▸[0m [39;1mCopying[0m WatchModel.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ iOS\ Tests.xctest
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/PlugIns/MindNode\ for\ iOS\ Tests.xctest
+[33m▸[0m [39;1mAnalyze[0m Succeeded
+[33m▸[0m [39;1mCleaning[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m Pods/Pods-MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCleaning[0m MindNode for iOS/MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mClean[0m Succeeded
+[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-watchOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Shared_watchOS_vers.c
+[33m▸[0m [39;1mLinking[0m Shared_watchOS
+[33m▸[0m [39;1mTouching[0m Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ Stickers/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNSMessagesStickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewHeader.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewCell.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerNeedsExportViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerSet.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNSStickerCollectionViewController.swift
+[33m▸[0m [39;1mCompiling[0m MindNode\ Stickers_vers.c
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m MindNode\ Stickers.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ Today\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeController.swift
+[33m▸[0m [39;1mCompiling[0m MNTRoundButton.swift
+[33m▸[0m [39;1mCompiling[0m MNCSharedAppGroup.swift
+[33m▸[0m [39;1mCompiling[0m MNTWidgetViewController.swift
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m MindNode\ Today\ Extension_vers.c
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCompiling[0m MainInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mTouching[0m MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c
+[33m▸[0m [39;1mLinking[0m CommonCrypto
+[33m▸[0m [39;1mCopying[0m CommonCrypto_iOS.h
+[33m▸[0m [39;1mTouching[0m CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info-iOS.plist
+[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift
+[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_iOS.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift
+[33m▸[0m [39;1mCompiling[0m Receipt.swift
+[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift
+[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift
+[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c
+[33m▸[0m [39;1mLinking[0m AppReceiptValidator
+[33m▸[0m [39;1mCopying[0m rc4.h
+[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h
+[33m▸[0m [39;1mCopying[0m cms.h
+[33m▸[0m [39;1mCopying[0m dh.h
+[33m▸[0m [39;1mCopying[0m sha.h
+[33m▸[0m [39;1mCopying[0m lhash.h
+[33m▸[0m [39;1mCopying[0m md5.h
+[33m▸[0m [39;1mCopying[0m ebcdic.h
+[33m▸[0m [39;1mCopying[0m ocsp.h
+[33m▸[0m [39;1mCopying[0m pkcs7.h
+[33m▸[0m [39;1mCopying[0m whrlpool.h
+[33m▸[0m [39;1mCopying[0m cmac.h
+[33m▸[0m [39;1mCopying[0m x509v3.h
+[33m▸[0m [39;1mCopying[0m conf.h
+[33m▸[0m [39;1mCopying[0m e_os2.h
+[33m▸[0m [39;1mCopying[0m rand.h
+[33m▸[0m [39;1mCopying[0m evp.h
+[33m▸[0m [39;1mCopying[0m x509.h
+[33m▸[0m [39;1mCopying[0m bio.h
+[33m▸[0m [39;1mCopying[0m mdc2.h
+[33m▸[0m [39;1mCopying[0m stack.h
+[33m▸[0m [39;1mCopying[0m rsa.h
+[33m▸[0m [39;1mCopying[0m opensslv.h
+[33m▸[0m [39;1mCopying[0m asn1t.h
+[33m▸[0m [39;1mCopying[0m objects.h
+[33m▸[0m [39;1mCopying[0m idea.h
+[33m▸[0m [39;1mCopying[0m ecdh.h
+[33m▸[0m [39;1mCopying[0m ecdsa.h
+[33m▸[0m [39;1mCopying[0m opensslconf.h
+[33m▸[0m [39;1mCopying[0m bn.h
+[33m▸[0m [39;1mCopying[0m ripemd.h
+[33m▸[0m [39;1mCopying[0m kssl.h
+[33m▸[0m [39;1mCopying[0m ui_compat.h
+[33m▸[0m [39;1mCopying[0m comp.h
+[33m▸[0m [39;1mCopying[0m krb5_asn.h
+[33m▸[0m [39;1mCopying[0m ec.h
+[33m▸[0m [39;1mCopying[0m x509_vfy.h
+[33m▸[0m [39;1mCopying[0m txt_db.h
+[33m▸[0m [39;1mCopying[0m cast.h
+[33m▸[0m [39;1mCopying[0m des.h
+[33m▸[0m [39;1mCopying[0m ssl2.h
+[33m▸[0m [39;1mCopying[0m pqueue.h
+[33m▸[0m [39;1mCopying[0m symhacks.h
+[33m▸[0m [39;1mCopying[0m srtp.h
+[33m▸[0m [39;1mCopying[0m ssl3.h
+[33m▸[0m [39;1mCopying[0m aes.h
+[33m▸[0m [39;1mCopying[0m dsa.h
+[33m▸[0m [39;1mCopying[0m engine.h
+[33m▸[0m [39;1mCopying[0m md4.h
+[33m▸[0m [39;1mCopying[0m ts.h
+[33m▸[0m [39;1mCopying[0m err.h
+[33m▸[0m [39;1mCopying[0m dso.h
+[33m▸[0m [39;1mCopying[0m rc2.h
+[33m▸[0m [39;1mCopying[0m hmac.h
+[33m▸[0m [39;1mCopying[0m conf_api.h
+[33m▸[0m [39;1mCopying[0m ossl_typ.h
+[33m▸[0m [39;1mCopying[0m crypto.h
+[33m▸[0m [39;1mCopying[0m srp.h
+[33m▸[0m [39;1mCopying[0m des_old.h
+[33m▸[0m [39;1mCopying[0m pem2.h
+[33m▸[0m [39;1mCopying[0m modes.h
+[33m▸[0m [39;1mCopying[0m ui.h
+[33m▸[0m [39;1mCopying[0m camellia.h
+[33m▸[0m [39;1mCopying[0m tls1.h
+[33m▸[0m [39;1mCopying[0m safestack.h
+[33m▸[0m [39;1mCopying[0m seed.h
+[33m▸[0m [39;1mCopying[0m asn1.h
+[33m▸[0m [39;1mCopying[0m blowfish.h
+[33m▸[0m [39;1mCopying[0m pkcs12.h
+[33m▸[0m [39;1mCopying[0m dtls1.h
+[33m▸[0m [39;1mCopying[0m buffer.h
+[33m▸[0m [39;1mCopying[0m pem.h
+[33m▸[0m [39;1mCopying[0m ssl.h
+[33m▸[0m [39;1mCopying[0m ssl23.h
+[33m▸[0m [39;1mCopying[0m obj_mac.h
+[33m▸[0m [39;1mCopying[0m asn1_mac.h
+[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m DebugAction+UIKit.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Platform.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#elseif (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                                       ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m Defaults.swift
+[33m▸[0m [39;1mCompiling[0m UserDebugging+iOS.swift
+[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift
+[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m SupportLink.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift
+[33m▸[0m [39;1mCompiling[0m WeakRef.swift
+[33m▸[0m [39;1mCompiling[0m DebugMenu.swift
+[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNCMirror.m
+[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m
+[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m Shared_vers.c
+[33m▸[0m [39;1mLinking[0m Shared
+[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h
+[33m▸[0m [39;1mCopying[0m MNCWeakArray.h
+[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h
+[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNFunctions.h
+[33m▸[0m [39;1mCopying[0m MNCMirror.h
+[33m▸[0m [39;1mTouching[0m Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist
+[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift
+[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift
+[33m▸[0m [39;1mCompiling[0m Archive.swift
+[33m▸[0m [39;1mCompiling[0m Data+Compression.swift
+[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+
+let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Entry.swift
+[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift
+[33m▸[0m [39;1mLinking[0m ZIPFoundation
+[33m▸[0m [39;1mTouching[0m ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist
+[33m▸[0m [39;1mCompiling[0m Mappings.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift
+[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift
+[33m▸[0m [39;1mCompiling[0m FontBuilder.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift
+[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift
+[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Ashton.swift
+[33m▸[0m [39;1mCompiling[0m Ashton_vers.c
+[33m▸[0m [39;1mLinking[0m Ashton
+[33m▸[0m [39;1mCopying[0m Ashton.h
+[33m▸[0m [39;1mTouching[0m Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser.m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser-iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage-dummy.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImage.m
+[33m▸[0m [39;1mCompiling[0m FLAnimatedImageView.m
+[33m▸[0m [39;1mBuilding library[0m libFLAnimatedImage.a
+[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer-dummy.m
+[33m▸[0m [39;1mCompiling[0m FTAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTImageAssetRenderer.m
+[33m▸[0m [39;1mCompiling[0m FTPDFAssetRenderer.m
+[33m▸[0m [39;1mBuilding library[0m libFTAssetRenderer.a
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch\ Extension/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchDocumentConnectivityController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m NodeDetailInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineRowController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineHeaderRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNWLocalizedString.swift
+[33m▸[0m [39;1mCompiling[0m WatchNode.swift
+[33m▸[0m [39;1mCompiling[0m WatchConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentReference.swift
+[33m▸[0m [39;1mCompiling[0m WatchExtensionDelegate.swift
+[33m▸[0m [39;1mCompiling[0m WatchTask.swift
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+WatchDefaults.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentController.swift
+[33m▸[0m [39;1mCompiling[0m InterfaceConstants.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsRowController.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceReader.swift
+[33m▸[0m [39;1mCompiling[0m WatchMindMap.swift
+[33m▸[0m [39;1mCompiling[0m PersistenceWriter.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsInterfaceController.swift
+[33m▸[0m [39;1mCompiling[0m PropertyWriter.swift
+[33m▸[0m [39;1mCompiling[0m PropertyReader.swift
+[33m▸[0m [39;1mCompiling[0m WKInterfaceLabel+MNHyphenation.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnvironment.swift
+[33m▸[0m [39;1mCompiling[0m RecentDocumentsEmptyRowController.swift
+[33m▸[0m [39;1mCompiling[0m MNColor+MindNode.swift
+[33m▸[0m [39;1mCompiling[0m ComplicationController.swift
+[33m▸[0m [39;1mCompiling[0m OutlineEmptyRowController.swift
+[33m▸[0m [39;1mPrecompiling[0m Extension-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MindNode\ for\ Apple\ Watch\ Extension_vers.c
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/Shared_watchOS.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex/Frameworks/Shared_watchOS.framework
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-HockeySDKResources-Info.plist
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/de.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/en.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/es.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fa.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/fr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hr.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/hu.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/it.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ja.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nb.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/nl.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt-PT.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/pt.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/ru.lproj
+[33m▸[0m [39;1mCopying[0m HockeySDK/HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDKResources.bundle/zh-Hans.lproj
+[33m▸[0m [39;1mTouching[0m HockeySDKResources.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/HockeySDK/HockeySDKResources.bundle
+[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m JLRoutes-dummy.m
+[33m▸[0m [39;1mCompiling[0m JLRoutes.m
+[33m▸[0m [39;1mBuilding library[0m libJLRoutes.a
+[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD-dummy.m
+[33m▸[0m [39;1mCompiling[0m MBProgressHUD.m
+[33m▸[0m [39;1mBuilding library[0m libMBProgressHUD.a
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MNCLogging-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m MNCLogging.m
+[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m
+[33m▸[0m [39;1mBuilding library[0m libMNCLogging-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet-dummy.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheet.m
+[33m▸[0m [39;1mCompiling[0m MTDActionSheetCell.m
+[33m▸[0m [39;1mBuilding library[0m libMTDActionSheet.a
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ResourceBundle-NYTPhotoViewer-Info.plist
+[33m▸[0m [39;1mTouching[0m NYTPhotoViewer.bundle
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/NYTPhotoViewer/NYTPhotoViewer.bundle
+[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSValue+PlatformIndependence.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation-dummy.m
+[33m▸[0m [39;1mCompiling[0m RBBAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBBlockBasedArray.m
+[33m▸[0m [39;1mCompiling[0m RBBCubicBezier.m
+[33m▸[0m [39;1mCompiling[0m RBBCustomAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBEasingFunction.m
+[33m▸[0m [39;1mCompiling[0m RBBLinearInterpolation.m
+[33m▸[0m [39;1mCompiling[0m RBBSpringAnimation.m
+[33m▸[0m [39;1mCompiling[0m RBBTweenAnimation.m
+[33m▸[0m [39;1mCompiling[0m UIColor+PlatformIndependence.m
+[33m▸[0m [39;1mBuilding library[0m libRBBAnimation.a
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAutoLayout-dummy.m
+[33m▸[0m [39;1mCompiling[0m UIView+SDCAutoLayout.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAutoLayout.a
+[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgement.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsParser.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController-dummy.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementsViewController.m
+[33m▸[0m [39;1mCompiling[0m VTAcknowledgementViewController.m
+[33m▸[0m [39;1mBuilding library[0m libVTAcknowledgementsViewController.a
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2Body.cpp
+[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mCompiling[0m b2Collision.cpp
+[33m▸[0m [39;1mCompiling[0m b2Contact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mCompiling[0m b2Distance.cpp
+[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Draw.cpp
+[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp
+[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Island.cpp
+[33m▸[0m [39;1mCompiling[0m b2Joint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Math.cpp
+[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Rope.cpp
+[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Settings.cpp
+[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Timer.cpp
+[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2World.cpp
+[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mCompiling[0m box2d-iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libbox2d-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m blocks.c
+[33m▸[0m [39;1mCompiling[0m buffer.c
+[33m▸[0m [39;1mCompiling[0m cmark-iOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m cmark.c
+[33m▸[0m [39;1mCompiling[0m cmark_ctype.c
+[33m▸[0m [39;1mCompiling[0m commonmark.c
+[33m▸[0m [39;1mCompiling[0m houdini_href_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_u.c
+[33m▸[0m [39;1mCompiling[0m html.c
+[33m▸[0m [39;1mCompiling[0m inlines.c
+[33m▸[0m [39;1mCompiling[0m iterator.c
+[33m▸[0m [39;1mCompiling[0m latex.c
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m man.c
+[33m▸[0m [39;1mCompiling[0m node.c
+[33m▸[0m [39;1mCompiling[0m references.c
+[33m▸[0m [39;1mCompiling[0m render.c
+[33m▸[0m [39;1mCompiling[0m scanners.c
+[33m▸[0m [39;1mCompiling[0m utf8.c
+[33m▸[0m [39;1mCompiling[0m xml.c
+[33m▸[0m [39;1mBuilding library[0m libcmark-iOS.a
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m NSBundle+NYTPhotoViewer.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoCaptionView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoDismissalInteractionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosDataSource.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosOverlayView.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotosViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionAnimator.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoTransitionController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewController.m
+[33m▸[0m [39;1mCompiling[0m NYTPhotoViewer-dummy.m
+[33m▸[0m [39;1mCompiling[0m NYTScalingImageView.m
+[33m▸[0m [39;1mBuilding library[0m libNYTPhotoViewer.a
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m SDCAlertAction.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertCollectionViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerCollectionViewFlowLayout.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerDefaultVisualStyle.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerScrollView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTextFieldViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerTransition.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertControllerView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertLabel.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertPresentationController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView-dummy.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewBackgroundView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewContentView.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewController.m
+[33m▸[0m [39;1mCompiling[0m SDCAlertViewCoordinator.m
+[33m▸[0m [39;1mCompiling[0m SDCIntrinsicallySizedView.m
+[33m▸[0m [39;1mCompiling[0m UIView+Parallax.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Current.m
+[33m▸[0m [39;1mBuilding library[0m libSDCAlertView.a
+[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m KeyboardLayoutGuide.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransitionCoordinator.swift
+[33m▸[0m [39;1mCompiling[0m PanelConstraints.swift
+[33m▸[0m [39;1mCompiling[0m PanelView.swift
+[33m▸[0m [39;1mCompiling[0m PanelDelegate.swift
+[33m▸[0m [39;1mCompiling[0m PanelAnimator.swift
+[33m▸[0m [39;1mCompiling[0m PanGestureRecognizer.swift
+[33m▸[0m [39;1mCompiling[0m PanelConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m ContainerView.swift
+[33m▸[0m [39;1mCompiling[0m UIViewController+Panel.swift
+[33m▸[0m [39;1mCompiling[0m SeparatorView.swift
+[33m▸[0m [39;1mCompiling[0m PanelTransition.swift
+[33m▸[0m [39;1mCompiling[0m ResizeHandle.swift
+[33m▸[0m [39;1mCompiling[0m ShadowView.swift
+[33m▸[0m [39;1mCompiling[0m PanelGestures.swift
+[33m▸[0m [39;1mCompiling[0m Panel.swift
+[33m▸[0m [39;1mCompiling[0m Aiolos_vers.c
+[33m▸[0m [39;1mLinking[0m Aiolos
+[33m▸[0m [39;1mCopying[0m Aiolos.h
+[33m▸[0m [39;1mTouching[0m Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Yellowstone/Yellowstone/Controller/ColorDragController.swift:26:10: [33mWeak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)[0m
+
+Linting 'HeaderView.swift' (19/22)
+[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ColorDragController.swift
+[33m▸[0m [39;1mCompiling[0m HeaderView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DataStore.swift
+[33m▸[0m [39;1mCompiling[0m ColorSelectionView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController+Configuration.swift
+[33m▸[0m [39;1mCompiling[0m ColorPalette.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerCell.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionView+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m FavoritesViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Color.swift
+[33m▸[0m [39;1mCompiling[0m FixedColorPaletteView.swift
+[33m▸[0m [39;1mCompiling[0m ColorPickerViewController.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColorPaletteViewModel.swift
+[33m▸[0m [39;1mCompiling[0m DerivedColors.swift
+[33m▸[0m [39;1mCompiling[0m UICollectionViewCell+Yellowstone.swift
+[33m▸[0m [39;1mCompiling[0m ApplyButton.swift
+[33m▸[0m [39;1mCompiling[0m AddFavoriteCell.swift
+[33m▸[0m [39;1mCompiling[0m Yellowstone_vers.c
+[33m▸[0m [39;1mLinking[0m Yellowstone
+[33m▸[0m [39;1mCopying[0m Yellowstone.h
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mTouching[0m Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m Reachability.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#if (arch(i386) || arch(x86_64)) && os(iOS)
+[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Reachability_vers.c
+[33m▸[0m [39;1mLinking[0m Reachability
+[33m▸[0m [39;1mCopying[0m Reachability.h
+[33m▸[0m [39;1mTouching[0m Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m MindNode\ for\ Apple\ Watch/Info.plist
+[33m▸[0m [39;1mCompiling[0m WatchInterface.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ iOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ iOS.a
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift
+[33m▸[0m [39;1mCompiling[0m TrialState.swift
+[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift
+[33m▸[0m [39;1mCompiling[0m SignedLicense.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift
+[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift
+[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift
+[33m▸[0m [39;1mCompiling[0m License.swift
+[33m▸[0m [39;1mCompiling[0m License+Products.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift
+[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProvider.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift
+[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift
+[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift
+[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift
+[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift
+[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift
+[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift
+[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService.swift
+[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Then.swift
+[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift
+[33m▸[0m [39;1mCompiling[0m VersionNumber.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift
+[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift
+[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c
+[33m▸[0m [39;1mLinking[0m Purchasing
+[33m▸[0m [39;1mCopying[0m Purchasing_iOS.h
+[33m▸[0m [39;1mTouching[0m Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mPreprocessing[0m Resources/MindNodeTouch-Info.plist
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Sources/First Launch/MNCWelcomeViewController.swift:206:10: [33minstance method 'updateConstraints(forViewSize:)' took 552ms to type-check (limit: 500ms)[0m
+
+func updateConstraints(forViewSize size: CGSize) {
+[36m         ^[0m
+
+
+[33m▸[0m [39;1mPrecompiling[0m Sources/Other/MindNodeTouch-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m UIFont+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m
+[33m▸[0m [39;1mCompiling[0m UIFontDescriptor+MNTDiscovery.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m
+[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m
+[33m▸[0m [39;1mCompiling[0m MNCPathView.m
+[33m▸[0m [39;1mCompiling[0m NSString+Paths.m
+[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCNode.m
+[33m▸[0m [39;1mCompiling[0m MNTStepperTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumCell.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNTKeyboardInformation.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m
+[33m▸[0m [39;1mCompiling[0m MNTTextFieldTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTFontDownloader.m
+[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeWebViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTColorViewInCell.m
+[33m▸[0m [39;1mCompiling[0m MNCExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalScreenViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeView.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m
+[33m▸[0m [39;1mCompiling[0m MNTOverlayView.m
+[33m▸[0m [39;1mCompiling[0m MNCDevice.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeStyleInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m
+[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTScrollView.m
+[33m▸[0m [39;1mCompiling[0m UIResponder+MNTFirstResponder.m
+[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTColorTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m
+[33m▸[0m [39;1mCompiling[0m MNTFontStyleViewController.m
+[33m▸[0m [39;1mCompiling[0m UICollectionReusableView+MNTReuseIdentifier.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionsBrowserViewController.m
+[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m
+[33m▸[0m [39;1mCompiling[0m MNCContent.m
+[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mCompiling[0m MNTSwitchTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m
+[33m▸[0m [39;1mCompiling[0m UIFont+MNCustomFont.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseViewController.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m
+[33m▸[0m [39;1mCompiling[0m MNTCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNTTextEditor.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentConflictResolutionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m
+[33m▸[0m [39;1mCompiling[0m MNTNavigationControllerTransitionDelegate.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAlbumPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m
+[33m▸[0m [39;1mCompiling[0m main.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m
+[33m▸[0m [39;1mCompiling[0m MNTShareViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeView.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m
+[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCAsset.m
+[33m▸[0m [39;1mCompiling[0m MNVector.m
+[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m
+[33m▸[0m [39;1mCompiling[0m MNTNotesDetailViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m
+[33m▸[0m [39;1mCompiling[0m MNTCrossConnectionInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTExportController.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionNode.m
+[33m▸[0m [39;1mCompiling[0m MNTQuickLookPhoto.m
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegistrationViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTLoadingIndicatorCell.m
+[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineSearchCell.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m UIButton+MNLongPress.m
+[33m▸[0m [39;1mCompiling[0m MNError.m
+[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTArrowTypeCell.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerManager.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionBorder.m
+[33m▸[0m [39;1mCompiling[0m MNTAppearance.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentPrinter.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionCrossConnection.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m
+[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeURLActivityItemProvider.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m
+[33m▸[0m [39;1mCompiling[0m MNTCanvasPrintSinglePageRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m
+[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m
+[33m▸[0m [39;1mCompiling[0m UIView+Animation.m
+[33m▸[0m [39;1mCompiling[0m MNTPathStyleCell.m
+[33m▸[0m [39;1mCompiling[0m MNTClipArtPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentSharableData.m
+[33m▸[0m [39;1mCompiling[0m MNTStepper.m
+[33m▸[0m [39;1mCompiling[0m MNCNote.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleController.m
+[33m▸[0m [39;1mCompiling[0m MNTAccessibilityCustomAction.m
+[33m▸[0m [39;1mCompiling[0m MNTKeyboardAccessory.m
+[33m▸[0m [39;1mCompiling[0m UIImage+MNBlockDrawing.m
+[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentVersionCell.m
+[33m▸[0m [39;1mCompiling[0m MNTRecentDocumentController.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadProgressViewController.m
+[33m▸[0m [39;1mCompiling[0m MNTWindow.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineBaseCell.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m
+[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCText.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNTPlaceholderTextView.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTTextFormatCell.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorSectionText.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentViewController.m
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/iOS/Sources/Document UI/MNTDocumentViewController.m:2085:9: [33mTODO: don't close if we resolved a conflict, but reload document [-W#pragma-messages][0m
+
+#pragma message("TODO: don't close if we resolved a conflict, but reload document")
+[36m        ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNTAccessibilityDefines.m
+[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m
+[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m
+[33m▸[0m [39;1mCompiling[0m MNTDocument.m
+[33m▸[0m [39;1mCompiling[0m MNTTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m UIBarButtonItem+MNLongPress.m
+[33m▸[0m [39;1mCompiling[0m MNTDateFormatter.m
+[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTFontPickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNTButtonCell.m
+[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSource.m
+[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArt.m
+[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCTextController.m
+[33m▸[0m [39;1mCompiling[0m MNTCircularProgressView.m
+[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m
+[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNTWebViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNTLightBoxView.m
+[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m
+[33m▸[0m [39;1mCompiling[0m UIMenuController+UserInfo.m
+[33m▸[0m [39;1mCompiling[0m UIApplication+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNTContentSizeTableViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm
+[33m▸[0m [39;1mCompiling[0m MNCFileLink.m
+[33m▸[0m [39;1mCompiling[0m MNTAppDelegate.m
+[33m▸[0m [39;1mCompiling[0m MNTImagePickerCell.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNTNodeShapeTypeCell.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m
+[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTOutlineCell.m
+[33m▸[0m [39;1mCompiling[0m MNCSearchableIndex.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNTApplication.m
+[33m▸[0m [39;1mCompiling[0m MNCTask.m
+[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNTDocumentUsage.m
+[33m▸[0m [39;1mCompiling[0m UIImage+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNTInteractionCanvasViewController+Actions.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m
+[33m▸[0m [39;1mCompiling[0m MNTCheckmarkTableViewCell.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNTCreditsViewController.m
+[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm
+[33m▸[0m [39;1mCompiling[0m UIImage+TintColor.m
+[33m▸[0m [39;1mCompiling[0m MNTExternalKeyboardManager.m
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m
+[33m▸[0m [39;1mCompiling[0m NSString+UUID.m
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+MNAccessibility.m
+[33m▸[0m [39;1mCompiling[0m MNTCollectionViewHeaderView.m
+[33m▸[0m [39;1mCompiling[0m MNTMindMapLayoutCell.m
+[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m
+[33m▸[0m [39;1mCompiling[0m UIScrollView+Scrolling.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm
+[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m
+[33m▸[0m [39;1mCompiling[0m UISearchBar+MNTCancellation.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m
+[33m▸[0m [39;1mCompiling[0m MNDefaults.m
+[33m▸[0m [39;1mCompiling[0m MNTMyMindNodeSafariActivity.m
+[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m
+[33m▸[0m [39;1mCompiling[0m MNTPhotoAssetsCollection.m
+[33m▸[0m [39;1mCompiling[0m MNTFontManager.m
+[33m▸[0m [39;1mCompiling[0m MNTFadeTransition.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSourceSection.m
+[33m▸[0m [39;1mCompiling[0m UIView+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m
+[33m▸[0m [39;1mCompiling[0m UIViewController+MNTModalSwipeDismiss.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNTCustomFontLabel.m
+[33m▸[0m [39;1mCompiling[0m MNTTextEditorView.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m
+[33m▸[0m [39;1mCompiling[0m SSWZip.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m
+[33m▸[0m [39;1mCompiling[0m MNCDataSourceItem.m
+[33m▸[0m [39;1mCompiling[0m MNTInspectorBaseTableViewController.m
+[33m▸[0m [39;1mLinking[0m MindNode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-acknowledgements.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromo.html
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer
+[33m▸[0m [39;1mCompiling[0m MNTFileProgressViewController.xib
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoAppIcon.pdf
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadFinishedViewController.xib
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme
+[33m▸[0m [39;1mCopying[0m credits.plist
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconMedal.svg
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Mac\ Promo/MNTMacPromoIconDevices.svg
+[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadStartViewController.xib
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer
+[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ iOS-metadata.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCompiling[0m MNTLaunchScreen.storyboard
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Today\ Extension.appex
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode\ Stickers.appex
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Ashton.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/AppReceiptValidator.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Reachability.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/ZIPFoundation.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Yellowstone.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Aiolos.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Ashton.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Shared.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Reachability.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/AppReceiptValidator.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Yellowstone.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/ZIPFoundation.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/Frameworks/Aiolos.framework
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app
+[33m▸[0m [39;1mBuild[0m Succeeded
+2018-04-04 14:53:32.877 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/Purchasing Tests iOS-AFE11490-CFBC-4EE6-A633-FD4F88CE9FE9/Session-Purchasing Tests iOS-2018-04-04_145332-pZIXfZ.log
+2018-04-04 14:53:32.883 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (F076D2C1-B0BE-4180-B2EB-E9E9CBB47A83) Beginning test session Purchasing Tests iOS-F076D2C1-B0BE-4180-B2EB-E9E9CBB47A83 at 2018-04-04 14:53:32.878 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+2018-04-04 14:53:32.906 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/Shared Tests iOS-D540EDE9-55EE-416D-9BEC-0A488BA1263B/Session-Shared Tests iOS-2018-04-04_145332-LQbMHs.log
+2018-04-04 14:53:32.907 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (9429E0D4-6FA2-4171-8528-6026249D4C5D) Beginning test session Shared Tests iOS-9429E0D4-6FA2-4171-8528-6026249D4C5D at 2018-04-04 14:53:32.907 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+2018-04-04 14:53:32.911 xcodebuild[94187:505005]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-3091BB18-748E-4036-9E5B-304B91B1690C/MindNode for iOS Tests-3C67590D-7820-4CBB-8B06-DEE503858BBF/Session-MindNode for iOS Tests-2018-04-04_145332-jmXwu8.log
+2018-04-04 14:53:32.911 xcodebuild[94187:492690] [MT] IDETestOperationsObserverDebug: (F9707EE0-F01C-4733-A477-3559139D4ACE) Beginning test session MindNode for iOS Tests-F9707EE0-F01C-4733-A477-3559139D4ACE at 2018-04-04 14:53:32.912 with Xcode 9E145 on target <DVTiPhoneSimulator: 0x7fe986695310> {
+SimDevice: iPhone 6s (C5E91E1A-FF7B-4D7A-81C1-C48707444457, iOS 11.3, Booted)
+} (11.3 (15E217))
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Stickers [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared watchOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode Today Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mBuilding[0m Shared/Shared iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch Extension [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mBuilding[0m Pods/FLAnimatedImage [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/FTAssetRenderer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/HockeySDK-HockeySDKResources [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/JLRoutes [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MBProgressHUD [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MTDActionSheet [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer-NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/RBBAnimation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAutoLayout [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/VTAcknowledgementsViewController [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/NYTPhotoViewer [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Aiolos/Aiolos [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Yellowstone/Yellowstone [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mBuilding[0m Reachability/Reachability [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/SDCAlertView [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared Tests iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-Tests-iOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m AppContextTests.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfigurationTests.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalErrorTests.swift
+[33m▸[0m [39;1mCompiling[0m ErrorComparisonTests.swift
+[33m▸[0m [39;1mCompiling[0m DefaultTests.swift
+[33m▸[0m [39;1mCompiling[0m Shared\ Tests\ iOS_vers.c
+[33m▸[0m [39;1mCompiling[0m ObjCTests.m
+[33m▸[0m [39;1mLinking[0m Shared\
+[33m▸[0m [39;1mTouching[0m Shared\ Tests\ iOS.xctest
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Shared\ Tests\ iOS.xctest
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for Apple Watch [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch\ Extension.appex
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m ViewController.swift
+[33m▸[0m [39;1mCompiling[0m AppDelegate.swift
+[33m▸[0m [39;1mLinking[0m Purchasing\
+[33m▸[0m [39;1mCompiling[0m LaunchScreen.storyboard
+[33m▸[0m [39;1mCompiling[0m Main.storyboard
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/CommonCrypto.framework
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/Frameworks/Purchasing.framework
+[33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ iOS.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-watchsimulator/MindNode\ for\ Apple\ Watch.app
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests iOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework
+[33m▸[0m [39;1mCompiling[0m VersionNumberTests.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptAssets.swift
+[33m▸[0m [39;1mCompiling[0m MockPurchasingServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m XCTestCase+ObservableAssertions.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdaterTests.swift
+[33m▸[0m [39;1mCompiling[0m TestAssetLoading.swift
+[33m▸[0m [39;1mCompiling[0m LicenseAssets.swift
+[33m▸[0m [39;1mCompiling[0m License+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidatorTests.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifierTests.swift
+[33m▸[0m [39;1mCompiling[0m CurrentReceiptValidationTests.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysisTests.swift
+[33m▸[0m [39;1mCompiling[0m MockDefaults.swift
+[33m▸[0m [39;1mCompiling[0m Date+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m DataStoreTestContext.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceTestContext.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStoreTests.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceTests.swift
+[33m▸[0m [39;1mCompiling[0m MockStorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+DemoData.swift
+[33m▸[0m [39;1mCompiling[0m MockStoreKitWrapper.swift
+[33m▸[0m [39;1mLinking[0m Purchasing\
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/wildcard.alamofire.org.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.2.3.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-root-ca.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity01
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/expired.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-dns-name.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial_and_full.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity02
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/missing-dns-name-and-uri.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01.txt
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_3394.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithoutTrial_SignedWithProduction.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity02_rsaCert.der
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-uri.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial_and_fullversion.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_michaelsandbox_receipt1.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_147.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicenseWithTrial_With_Identity01.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity02
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicense_With_Identity01.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity01
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/MindNodeLicensingProduction_rsaCert.der
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca2.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_vpp.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_fullversionfree.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.5.7.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca1.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02.txt
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/test.alamofire.org.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_vpp.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/multiple-dns-names.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca1.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithTrial_SignedWithProduction.json
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca2.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity01_rsaCert.der
+[33m▸[0m [39;1mTouching[0m Purchasing\ Tests\ iOS.xctest
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/Purchasing\ Demo\ iOS.app/PlugIns/Purchasing\ Tests\ iOS.xctest
+[33m▸[0m [39;1mBuilding[0m MindNode for iOS/MindNode for iOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Preprocessed-Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mCompiling[0m MNTDocumentControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCAppLauncherTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFunctionsTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCollisionControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMindMapTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeLayoutCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCSetSynchronizerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeHierarchyControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCPropertyRepresentationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontManagerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTUserIntentValidatorTests.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:569:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+].flatMap { $0 }
+[36m              ^[0m
+
+
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNTUserIntentValidatorTests.swift:645:15: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+].flatMap { $0 }
+[36m              ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCLayoutCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextOutlineImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCZoomingCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCHelloPayloadBuilderTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeDataSourceTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCThingsExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextBundleExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontStyleTests.swift
+[33m▸[0m [39;1mCompiling[0m NSAttributedStringMarkdownTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCXMindImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocument5to6MigrationControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m NSRangeSwiftTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCSVExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCiThoughtsImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNColorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCSVImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTReviewDisplayLogicTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m WatchTransferStatusTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTheme2to3MigrationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCNodeControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskPaperExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMindJetImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentOpenPerformanceTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCFontExtractorTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCBoundaryMorphTests.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }
+[36m              ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCCanvasControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCStyleDocument1To2MigrationTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCDocumentVersionDecisionTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCImageExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCCanvasTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTextBundleImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNImage+ImageDiff.swift
+[33m▸[0m [39;1mCompiling[0m MNCThemeManagerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCOPMLImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m WatchDocumentExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskControllerTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCInsertPositionCalculatorTests.swift
+[33m▸[0m [39;1mCompiling[0m XCTestCase+DocumentHelper.swift
+[33m▸[0m [39;1mCompiling[0m MNCPasteboardTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCAccessibilityTextExporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeTokenStoreTests.swift
+[33m▸[0m [39;1mCompiling[0m MNCTaskPaperImporterTests.swift
+[33m▸[0m [39;1mCompiling[0m MNTextTests.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mGenerating 'MindNode\ for\ iOS\ Tests.xctest.dSYM'[0m
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode
+[33m▸[0m [39;1mCopying[0m WatchModel.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ iOS\ Tests.xctest
+[33m▸[0m [39;1mSigning[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug-iphonesimulator/MindNode.app/PlugIns/MindNode\ for\ iOS\ Tests.xctest
+[39;1mSelected tests[0m
+Test Suite [39;1mPurchasing Tests iOS.xctest[0m started
+[39;1mCurrentReceiptParsingTests[0m
+[32;1m✓[0m testiOSReceiptValidation ([33m0.040[0m seconds)
+[32;1m✓[0m testMacOSReceiptValidation (0.007 seconds)
+[39;1mLicenseValidatorTests[0m
+[32;1m✓[0m testBrokenLicenseData (0.006 seconds)
+[32;1m✓[0m testBrokenSignedLicenseData (0.001 seconds)
+[32;1m✓[0m testEmtpyData (0.001 seconds)
+[32;1m✓[0m testMissingData (0.001 seconds)
+[32;1m✓[0m testParsingSignedLicense1 (0.002 seconds)
+[32;1m✓[0m testValidatingSignedLicense (0.005 seconds)
+[32;1m✓[0m testValidatingSignedLicenseWithTrial (0.003 seconds)
+[32;1m✓[0m testValidatingSignedProductionLicense (0.002 seconds)
+[32;1m✓[0m testValidatingSignedProductionLicenseWithTrial (0.003 seconds)
+[32;1m✓[0m testValidatingSkippingCertificate (0.002 seconds)
+[32;1m✓[0m testValidatingSkippingDeviceIdentifier (0.004 seconds)
+[32;1m✓[0m testWrongCertificate (0.004 seconds)
+[32;1m✓[0m testWrongDeviceIdentifier (0.006 seconds)
+[32;1m✓[0m testWrongDeviceIdentifierAndCertificate (0.003 seconds)
+[39;1mPromotedVisibilityUpdaterTests[0m
+[32;1m✓[0m testCatalogNeeded (0.002 seconds)
+[32;1m✓[0m testDoubleUpdateProtection (0.005 seconds)
+[32;1m✓[0m testInitialVisibilityUpdates (0.001 seconds)
+[32;1m✓[0m testOverriddenUpdating (0.002 seconds)
+[32;1m✓[0m testVisibiliesForFullVersion (0.002 seconds)
+[32;1m✓[0m testVisibiliesFromTrial (0.004 seconds)
+[32;1m✓[0m testVisibilitiesForPendingDecision (0.004 seconds)
+[39;1mPurchaseServiceDataStoreTests[0m
+[32;1m✓[0m testPersistence (0.002 seconds)
+[32;1m✓[0m testUpdateMethods (0.004 seconds)
+[39;1mPurchaseServiceTests[0m
+[32;1m✓[0m testActiveTrialLicenseTrumpsViewerOnly (0.010 seconds)
+[32;1m✓[0m testAdditionalAvailableDiscountedProductOverrulesReceipt (0.006 seconds)
+[32;1m✓[0m testFromExpiredIAPTrialToViewerOnly (0.007 seconds)
+[32;1m✓[0m testFromIAPTrialToViewerOnly (0.005 seconds)
+[32;1m✓[0m testFullPurchase (0.008 seconds)
+[32;1m✓[0m testFullPurchaseFromTrialLicense (0.008 seconds)
+[32;1m✓[0m testIAPTrialExpiry (0.021 seconds)
+[32;1m✓[0m testIAPTrialVsLongerTrialLicense (0.005 seconds)
+[32;1m✓[0m testIAPTrialVsShorterTrialLicense (0.005 seconds)
+[32;1m✓[0m testLicenseTrialExpiry (0.023 seconds)
+[32;1m✓[0m testPurchaseServiceInitializationWithExistingLicense (0.010 seconds)
+[32;1m✓[0m testPurchaseServiceInitializationWithoutExistingLicense (0.008 seconds)
+[32;1m✓[0m testPurchaseServiceInvalidReceiptData (0.006 seconds)
+[32;1m✓[0m testReceiptOverrulesAdditionalAvailableDiscountedProduct (0.004 seconds)
+[32;1m✓[0m testStartingTrial (0.007 seconds)
+[32;1m✓[0m testViewerOnlyThenTrialLicenseThenViewerOnly (0.008 seconds)
+[39;1mSignatureVerifierTests[0m
+[32;1m✓[0m testCorrectSignatures (0.005 seconds)
+[32;1m✓[0m testMalformedData (0.002 seconds)
+[32;1m✓[0m testMalformedSignatureData (0.002 seconds)
+[32;1m✓[0m testMlformedCertificateData (0.002 seconds)
+[33m◷[0m testPerformanceOfSignatureVerification measured (0.000 seconds)
+[32;1m✓[0m testPerformanceOfSignatureVerification ([31m0.545[0m seconds)
+[32;1m✓[0m testWrongSignatures (0.010 seconds)
+[39;1mUpgradePathAnalysisTests[0m
+[32;1m✓[0m testConcreteiOSUpgradePathAnalysis (0.007 seconds)
+[32;1m✓[0m testConcreteMacOSUpgradePathAnalysis (0.002 seconds)
+[32;1m✓[0m testiOSLegacyReceiptParsing (0.008 seconds)
+[32;1m✓[0m testMacOSLegacyReceiptParsing (0.005 seconds)
+[39;1mVersionNumberTests[0m
+[32;1m✓[0m testDigitsAndDotsComparison (0.001 seconds)
+[32;1m✓[0m testDigitsAndDotsParsing (0.001 seconds)
+[32;1m✓[0m testDigitsOnly (0.001 seconds)
+[32;1m✓[0m testDigitsOnlyParsing (0.001 seconds)
+
+
+[32;1m	 Executed 55 tests, with 0 failures (0 unexpected) in 0.846 (0.914) seconds
+[0m
+[39;1mAll tests[0m
+Test Suite [39;1mShared Tests iOS.xctest[0m started
+[39;1mAppContextInfoTests[0m
+[32;1m✓[0m testFallbacking (0.004 seconds)
+[32;1m✓[0m testNonEmptyCurrentAppContextDeviceInfo (0.001 seconds)
+[32;1m✓[0m testNonEmptyCurrentDeviceInfo (0.000 seconds)
+[32;1m✓[0m testUserAgent (0.001 seconds)
+[39;1mDefaultTests[0m
+[32;1m✓[0m testBool (0.011 seconds)
+[32;1m✓[0m testData (0.003 seconds)
+[32;1m✓[0m testDate (0.002 seconds)
+[32;1m✓[0m testDouble (0.002 seconds)
+[32;1m✓[0m testInt (0.003 seconds)
+[32;1m✓[0m testString (0.001 seconds)
+[39;1mErrorComparisonTests[0m
+[32;1m✓[0m testErrorEnumComparison (0.008 seconds)
+[32;1m✓[0m testNSErrorComparison (0.001 seconds)
+[39;1mHierarchicalErrorTests[0m
+[32;1m✓[0m testComplexHierarchy (0.002 seconds)
+[32;1m✓[0m testHierarchicalError (0.001 seconds)
+[32;1m✓[0m testUnderlyingNetworkError (0.001 seconds)
+[39;1mMessageConfigurationTests[0m
+[32;1m✓[0m testActionCount (0.001 seconds)
+[32;1m✓[0m testErrorLocalizationWithMessage (0.001 seconds)
+[32;1m✓[0m testErrorLocalizationWithMessageCustomActions (0.001 seconds)
+[32;1m✓[0m testMessageConfigurationFromLocalizedError (0.001 seconds)
+[32;1m✓[0m testMessageConfigurationFromLocalizedErrorWithDescription (0.001 seconds)
+[32;1m✓[0m testMessageConfigurationFromLocalizedErrorWithNotMuchAtAll (0.001 seconds)
+[32;1m✓[0m testMessageConfigurationFromNSError (0.001 seconds)
+[32;1m✓[0m testOKButtonExists (0.001 seconds)
+[39;1mObjCTests[0m
+[32;1m✓[0m testContainsObject (0.001 seconds)
+[32;1m✓[0m testFastEnumeration (0.001 seconds)
+[32;1m✓[0m testThatAddObjectAddsToWeakArray (0.001 seconds)
+[32;1m✓[0m testThatFirstAndLastObjectReturnCorrectObject (0.001 seconds)
+[32;1m✓[0m testThatFirstAndLastObjectReturnNilForEmptyArray (0.001 seconds)
+[32;1m✓[0m testThatObjectsAreReferencedWeakly (0.001 seconds)
+[32;1m✓[0m testThatRemoveAllObjectsEmptiesWeakArray (0.001 seconds)
+[32;1m✓[0m testThatRemoveObjectCompactsWeakArray (0.001 seconds)
+[32;1m✓[0m testThatWeakArrayIsEmpty (0.001 seconds)
+
+
+[32;1m	 Executed 32 tests, with 0 failures (0 unexpected) in 0.054 (0.073) seconds
+[0m
+[39;1mAll tests[0m
+Test Suite [39;1mMindNode for iOS Tests.xctest[0m started
+[39;1mMNCAccessibilityTextExporterTests[0m
+[32;1m✓[0m testAccessibilityTextExportForCanvasWithSeveralMindMaps ([33m0.026[0m seconds)
+[32;1m✓[0m testAccessibilityTextExportForNode (0.005 seconds)
+[39;1mMNCAppLaunchCounterTests[0m
+[32;1m✓[0m testMaxAppLaunches (0.015 seconds)
+[32;1m✓[0m testShortAppLaunchInterval (0.002 seconds)
+[32;1m✓[0m testThatOnly1LaunchPerDayGetsRegistered (0.001 seconds)
+[39;1mMNCCSVExporterTests[0m
+[32;1m✓[0m testCounterOfLevels ([31m0.158[0m seconds)
+[32;1m✓[0m testCSV ([31m0.206[0m seconds)
+[32;1m✓[0m testCSVisNotEmpty ([31m0.427[0m seconds)
+[32;1m✓[0m testHeader ([33m0.098[0m seconds)
+[39;1mMNCCSVImporterTests[0m
+[32;1m✓[0m testImport ([31m0.560[0m seconds)
+[32;1m✓[0m testMainNodes ([33m0.062[0m seconds)
+[32;1m✓[0m testStructure ([33m0.064[0m seconds)
+[32;1m✓[0m testTotalNodes ([33m0.065[0m seconds)
+[39;1mMNCCanvasControllerTests[0m
+[32;1m✓[0m testCanvasControllerSetup ([33m0.031[0m seconds)
+[32;1m✓[0m testInsertParentNode ([31m0.137[0m seconds)
+[32;1m✓[0m testRemoveAllNodes ([33m0.030[0m seconds)
+[32;1m✓[0m testRemoveNode ([33m0.032[0m seconds)
+[32;1m✓[0m testRemoveNodeAndSubnodes ([33m0.030[0m seconds)
+[32;1m✓[0m testRepresentedObject ([33m0.035[0m seconds)
+[39;1mMNCCanvasSelectionControllerTests[0m
+[32;1m✓[0m testCanvasSelectionConvenienceGetters (0.005 seconds)
+[32;1m✓[0m testCanvasSelectionEqualsSelectionController (0.003 seconds)
+[32;1m✓[0m testCanvasSelectionGetsResetAfterSelectionChange (0.003 seconds)
+[39;1mMNCCanvasTests[0m
+[32;1m✓[0m testAddNode (0.001 seconds)
+[32;1m✓[0m testRemoveAllNodes (0.001 seconds)
+[39;1mMNCCollisionControllerTests[0m
+[32;1m✓[0m testBoundsCollision ([31m0.145[0m seconds)
+[32;1m✓[0m testMindMapControllerSelectionMovement ([31m0.191[0m seconds)
+[32;1m✓[0m testRectHitTest ([31m0.113[0m seconds)
+[39;1mMNCDocument4to5MigrationControllerTests[0m
+[32;1m✓[0m testMigration ([31m1.080[0m seconds)
+[32;1m✓[0m testTextMigration ([31m0.102[0m seconds)
+[39;1mMNCDocument5to6MigrationControllerTests[0m
+[32;1m✓[0m testMigration ([33m0.034[0m seconds)
+[39;1mMNCDocumentKVOControllerTests[0m
+[32;1m✓[0m testNearestMindMapObject ([31m0.123[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault ([31m0.102[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft ([33m0.093[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleDefault ([33m0.092[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleLeft ([33m0.090[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleManual ([33m0.093[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleRight ([33m0.091[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault ([33m0.092[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight ([33m0.094[0m seconds)
+[32;1m✓[0m testSortingTaskStateRightAligned ([33m0.081[0m seconds)
+[39;1mMNCDocumentOpenPerformanceTests[0m
+[33m◷[0m testLargeMindMapWithTasks measured ([31m1.689[0m seconds)
+[32;1m✓[0m testLargeMindMapWithTasks ([31m19.159[0m seconds)
+[33m◷[0m testMindMapWithLotsOfCrossConnections measured ([31m3.101[0m seconds)
+[32;1m✓[0m testMindMapWithLotsOfCrossConnections ([31m31.265[0m seconds)
+[33m◷[0m testMindMapWithLotsOfNodes measured ([31m5.284[0m seconds)
+[32;1m✓[0m testMindMapWithLotsOfNodes ([31m53.095[0m seconds)
+[39;1mMNCDocumentTests[0m
+[32;1m✓[0m testOpenDocumentWithUnsupportedVersionNumbers ([33m0.035[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion4 ([33m0.097[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion5 ([33m0.098[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion6 ([31m0.103[0m seconds)
+[32;1m✓[0m testOpeningEmptyDocument ([33m0.064[0m seconds)
+[32;1m✓[0m testOpenMindNodeTouchDocument ([33m0.040[0m seconds)
+[39;1mMNCDocumentVersionDecisionTests[0m
+[32;1m✓[0m testExport (0.001 seconds)
+[32;1m✓[0m testNewDocument (0.000 seconds)
+[32;1m✓[0m testOpenDocument (0.001 seconds)
+[39;1mMNCFontExtractorTests[0m
+[32;1m✓[0m testCompoundEmoji (0.002 seconds)
+[32;1m✓[0m testEmoji (0.001 seconds)
+[32;1m✓[0m testEmptyString (0.000 seconds)
+[32;1m✓[0m testFontStyle (0.001 seconds)
+[32;1m✓[0m testFullyEmojiString (0.001 seconds)
+[32;1m✓[0m testFullySymbolic (0.001 seconds)
+[32;1m✓[0m testFullySymbolicAndEmojiString (0.001 seconds)
+[32;1m✓[0m testNormalFont (0.001 seconds)
+[32;1m✓[0m testSymbol (0.001 seconds)
+[32;1m✓[0m testSymbolAndEmoji (0.001 seconds)
+[39;1mMNCFontManagerTests[0m
+[32;1m✓[0m testRandomGeneratedFontConversion1 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion10 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion100 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion11 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion12 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion13 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion14 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion15 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion16 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion17 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion18 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion19 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion2 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion20 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion21 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion22 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion23 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion24 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion25 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion26 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion27 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion28 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion29 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion3 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion30 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion31 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion32 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion33 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion34 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion35 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion36 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion37 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion38 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion39 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion4 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion40 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion41 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion42 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion43 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion44 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion45 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion46 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion47 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion48 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion49 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion5 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion50 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion51 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion52 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion53 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion54 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion55 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion56 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion57 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion58 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion59 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion6 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion60 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion61 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion62 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion63 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion64 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion65 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion66 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion67 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion68 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion69 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion7 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion70 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion71 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion72 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion73 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion74 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion75 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion76 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion77 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion78 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion79 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion8 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion80 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion81 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion82 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion83 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion84 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion85 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion86 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion87 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion88 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion89 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion9 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion90 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion91 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion92 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion93 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion94 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion95 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion96 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion97 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion98 (0.000 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion99 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily1 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily2 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily3 (0.000 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily4 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily5 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily6 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily1 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily10 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily11 (0.000 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily12 (0.002 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily13 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily14 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily2 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily3 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily4 (0.000 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily5 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily6 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily7 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily8 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily9 (0.001 seconds)
+[39;1mMNCFontStyleTests[0m
+[32;1m✓[0m testAttributedStringInit (0.001 seconds)
+[32;1m✓[0m testNilInit (0.001 seconds)
+[32;1m✓[0m testNodeRewire ([31m0.101[0m seconds)
+[32;1m✓[0m testNormalInit (0.001 seconds)
+[32;1m✓[0m testSymbolCharacter (0.001 seconds)
+[39;1mMNCFreeMindImporterTests[0m
+[32;1m✓[0m testBranchWidth ([31m0.309[0m seconds)
+[32;1m✓[0m testBubbleShape ([31m0.205[0m seconds)
+[32;1m✓[0m testCustomTitleColor ([31m0.202[0m seconds)
+[32;1m✓[0m testImport ([31m0.205[0m seconds)
+[32;1m✓[0m testLinks ([31m0.204[0m seconds)
+[32;1m✓[0m testMainNodeHasPillShape ([31m0.203[0m seconds)
+[32;1m✓[0m testNodeAlignment ([31m0.208[0m seconds)
+[32;1m✓[0m testNodeAttributedTitle ([31m0.204[0m seconds)
+[32;1m✓[0m testNodeTitle ([31m0.202[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([31m0.211[0m seconds)
+[32;1m✓[0m testParsesBranchColor ([31m0.205[0m seconds)
+[32;1m✓[0m testShapeFillColor ([31m0.199[0m seconds)
+[32;1m✓[0m testSpecialCharactersDecoding ([33m0.053[0m seconds)
+[32;1m✓[0m testThatCrossConnectionsAreConnectingCorrectNodes ([31m0.205[0m seconds)
+[32;1m✓[0m testThatCrossConnectionsAreImported ([31m0.203[0m seconds)
+[32;1m✓[0m testThatCrossConnectionsHaveCorrectColor ([31m0.204[0m seconds)
+[32;1m✓[0m testThatFoldingIsRespected ([31m0.204[0m seconds)
+[32;1m✓[0m testThatFontNamesAreParsed ([31m0.199[0m seconds)
+[32;1m✓[0m testThatFontSizesAreParsed ([31m0.204[0m seconds)
+[32;1m✓[0m testThatNodesDeriveBubbleStyleFromParent ([31m0.205[0m seconds)
+[32;1m✓[0m testThatNodesDerivedBubbleStyleCanOverrideFillColor ([31m0.204[0m seconds)
+[32;1m✓[0m testThatNodesDerivedBubbleStyleDoesntHaveDerivedFillColor ([31m0.204[0m seconds)
+[32;1m✓[0m testThatNotesAreImported ([31m0.409[0m seconds)
+[32;1m✓[0m testThatParsesForkStyle ([31m0.208[0m seconds)
+[39;1mMNCFunctionsTests[0m
+[32;1m✓[0m testCGFloatEquality (0.001 seconds)
+[32;1m✓[0m testStringByRemovingCharactersInSet (0.001 seconds)
+[39;1mMNCHelloPayloadBuilderTests[0m
+[32;1m✓[0m testPayloadConstruction (0.004 seconds)
+[39;1mMNCImageExporterTests[0m
+[32;1m✓[0m testImageRepresentation ([31m2.908[0m seconds)
+[32;1m✓[0m testImageRepresentationWithoutBackground ([31m3.379[0m seconds)
+[32;1m✓[0m testImageRepresentationWithPadding ([31m2.677[0m seconds)
+[32;1m✓[0m testImageRepresentationWithScaling ([31m9.974[0m seconds)
+[39;1mMNCInsertPositionCalculatorTests[0m
+[32;1m✓[0m testInsertionOfSiblingsAboveAndBelow (0.003 seconds)
+[32;1m✓[0m testInsertPositionForManualLeftRightLayout (0.003 seconds)
+[32;1m✓[0m testInsertPositionForTopDownLayout (0.002 seconds)
+[39;1mMNCLayoutCalculatorTests[0m
+[32;1m✓[0m testHorizontalLayout (0.003 seconds)
+[33m◷[0m testHorizontalLayoutCalculationPerformance measured (0.016 seconds)
+[32;1m✓[0m testHorizontalLayoutCalculationPerformance ([31m2.029[0m seconds)
+[32;1m✓[0m testLayoutForLargeSupernodes (0.002 seconds)
+[32;1m✓[0m testVerticalLayout (0.003 seconds)
+[33m◷[0m testVerticalLayoutCalculationPerformance measured (0.016 seconds)
+[32;1m✓[0m testVerticalLayoutCalculationPerformance ([31m2.060[0m seconds)
+[39;1mMNCLayoutControllerTests[0m
+[32;1m✓[0m testDefaultLayoutControllerDeterminism ([33m0.089[0m seconds)
+[32;1m✓[0m testLayoutStyleChange0 ([31m0.180[0m seconds)
+[32;1m✓[0m testLayoutStyleChange1 ([31m0.182[0m seconds)
+[32;1m✓[0m testLayoutStyleChange2 ([31m0.188[0m seconds)
+[32;1m✓[0m testLayoutStyleChange3 ([31m0.183[0m seconds)
+[32;1m✓[0m testLayoutStyleChange4 ([31m0.193[0m seconds)
+[32;1m✓[0m testLayoutStyleChange5 ([31m0.205[0m seconds)
+[39;1mMNCMarkdownExporterTests[0m
+[32;1m✓[0m testMarkdownExportWithImages ([31m0.154[0m seconds)
+[32;1m✓[0m testMarkdownExportWithoutImages ([31m0.153[0m seconds)
+[39;1mMNCMarkdownImporterTests[0m
+[32;1m✓[0m testContent ([33m0.050[0m seconds)
+[32;1m✓[0m testExportImportRoundTrip ([31m0.109[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.033[0m seconds)
+[32;1m✓[0m testStructure ([33m0.033[0m seconds)
+[32;1m✓[0m testTodos ([33m0.034[0m seconds)
+[39;1mMNCMindJetImporterTests[0m
+[32;1m✓[0m testCrossConnections ([31m0.243[0m seconds)
+[32;1m✓[0m testExportedBackgroundColor ([31m0.474[0m seconds)
+[32;1m✓[0m testExportedNodeTextFormatting ([31m0.487[0m seconds)
+[32;1m✓[0m testHyperlinks ([31m0.230[0m seconds)
+[32;1m✓[0m testImages ([31m0.232[0m seconds)
+[32;1m✓[0m testImport ([31m0.235[0m seconds)
+[32;1m✓[0m testNodeAlignment ([31m0.236[0m seconds)
+[32;1m✓[0m testNodeFormatting ([31m0.232[0m seconds)
+[32;1m✓[0m testNodeText ([31m0.229[0m seconds)
+[32;1m✓[0m testNodeTextFormatting ([31m0.226[0m seconds)
+[32;1m✓[0m testNotes ([31m0.228[0m seconds)
+[32;1m✓[0m testNotesAndHyperlinkOnSameNode ([31m0.226[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([31m0.231[0m seconds)
+[32;1m✓[0m testTaskStatus ([31m0.481[0m seconds)
+[39;1mMNCMindMapTests[0m
+[32;1m✓[0m testImportWithInvalidLayoutStyle (0.001 seconds)
+[39;1mMNCMyMindNodeTokenStoreTests[0m
+[32;1m✓[0m testMyMindNodeKeyRetrieval (0.001 seconds)
+[32;1m✓[0m testTokenStoring (0.001 seconds)
+[39;1mMNCNodeControllerTests[0m
+[32;1m✓[0m testParsingOfNodeDataFromTitle (0.003 seconds)
+[39;1mMNCNodeHierarchyTests[0m
+[32;1m✓[0m testEmptyNodeHierarchy (0.001 seconds)
+[32;1m✓[0m testManualNodeHierarchy (0.001 seconds)
+[32;1m✓[0m testNodeHierarchyOfOpenedDocument ([31m0.202[0m seconds)
+[32;1m✓[0m testNodeRewire ([31m0.215[0m seconds)
+[32;1m✓[0m testNodeRewireWith2MindMaps ([31m0.178[0m seconds)
+[39;1mMNCNodeLayoutCalculatorTests[0m
+[32;1m✓[0m testNodeLayoutCalculation (0.002 seconds)
+[39;1mMNCOPMLImporterTests[0m
+[32;1m✓[0m testNumberOfNodes ([33m0.032[0m seconds)
+[32;1m✓[0m testSpecialSingleChildCase (0.015 seconds)
+[32;1m✓[0m testStructure ([33m0.030[0m seconds)
+[32;1m✓[0m testTasks ([33m0.031[0m seconds)
+[39;1mMNCPasteboardTests[0m
+[32;1m✓[0m testCanvasObjectPasteboardParserRoundTrip ([31m0.265[0m seconds)
+[32;1m✓[0m testEmptyPasteboard (0.012 seconds)
+[32;1m✓[0m testPasteboardCanvasObject ([33m0.046[0m seconds)
+[32;1m✓[0m testPasteboardController ([31m0.620[0m seconds)
+[32;1m✓[0m testPasteboardEmptyString (0.018 seconds)
+[32;1m✓[0m testPasteboardImage ([31m0.163[0m seconds)
+[32;1m✓[0m testPasteboardString ([31m0.195[0m seconds)
+[39;1mMNCSetSynchronizerTests[0m
+[32;1m✓[0m testInitialSyncMerging (0.001 seconds)
+[32;1m✓[0m testOurAddition (0.000 seconds)
+[32;1m✓[0m testOurAdditionTheirAddition (0.000 seconds)
+[32;1m✓[0m testOurAdditionTheirRemoval (0.001 seconds)
+[32;1m✓[0m testOurRemoval (0.001 seconds)
+[32;1m✓[0m testOurRemovalTheirAddition (0.001 seconds)
+[32;1m✓[0m testOurRemovalTheirRemoval (0.001 seconds)
+[32;1m✓[0m testSyncFailureRollback (0.001 seconds)
+[32;1m✓[0m testThatInvalidStateExceptionIsThrown (0.000 seconds)
+[32;1m✓[0m testTheirAddition (0.001 seconds)
+[32;1m✓[0m testTheirRemoval (0.000 seconds)
+[39;1mMNCSpotlightImporterTests[0m
+[32;1m✓[0m testV4SpotlightIndexerForValidDocument (0.005 seconds)
+[32;1m✓[0m testV5SpotlightIndexerForBigDocument ([33m0.063[0m seconds)
+[32;1m✓[0m testV5SpotlightIndexerForEmptyDocument (0.005 seconds)
+[32;1m✓[0m testV5SpotlightIndexerForValidDocument (0.007 seconds)
+[32;1m✓[0m testV5SpotlightIndexerWithCrossConnectionTitle (0.005 seconds)
+[32;1m✓[0m testV5SpotlightIndexerWithNotes (0.005 seconds)
+[32;1m✓[0m testV6SpotlightIndexer (0.006 seconds)
+[39;1mMNCStyleDocument1to2MigrationTests[0m
+[32;1m✓[0m testThatStyleDocumentUpgradeAndDowngradeResultsInOriginalStyleDocument (0.009 seconds)
+[39;1mMNCStyleProxyTests[0m
+[32;1m✓[0m testBoxing ([33m0.066[0m seconds)
+[32;1m✓[0m testKeyPathAccess ([33m0.064[0m seconds)
+[32;1m✓[0m testStyleProxyObjectUpdate ([33m0.068[0m seconds)
+[32;1m✓[0m testTextManipulation ([33m0.072[0m seconds)
+[32;1m✓[0m testTextSpecialCase ([33m0.074[0m seconds)
+[32;1m✓[0m testThatRemovingLastObjectResultsInEmptyStyleProxy ([33m0.062[0m seconds)
+[32;1m✓[0m testThatRemovingOfValuesResultsInCorrectStyleValue ([33m0.067[0m seconds)
+[32;1m✓[0m testValueTransformer ([33m0.068[0m seconds)
+[39;1mMNCTaskControllerTest[0m
+[33m◷[0m testActivatingDeactivatingTaskStatePerformance measured ([31m0.583[0m seconds)
+[32;1m✓[0m testActivatingDeactivatingTaskStatePerformance ([31m7.866[0m seconds)
+[32;1m✓[0m testMultipleTaskSettingOnDeepTree (0.002 seconds)
+[32;1m✓[0m testProgressCalculationOnDeepTree (0.002 seconds)
+[32;1m✓[0m testProgressCalculationOnFlatTree (0.001 seconds)
+[32;1m✓[0m testRefreshOfStatesOnDeepTree (0.003 seconds)
+[32;1m✓[0m testRefreshOfStatesOnFlatTree (0.001 seconds)
+[33m◷[0m testRefreshPerformance measured ([33m0.033[0m seconds)
+[32;1m✓[0m testRefreshPerformance ([31m2.272[0m seconds)
+[32;1m✓[0m testShowTaskControlOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTaskCreationViaTitle (0.004 seconds)
+[32;1m✓[0m testTaskPropagationOnDeepTree (0.002 seconds)
+[32;1m✓[0m testTaskPropagationOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTogglingNodeStatesOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTogglingOfCompletionStateOnDeepTree (0.002 seconds)
+[32;1m✓[0m testTogglingOfTaskStatesOnDeepTree (0.002 seconds)
+[33m◷[0m testTogglingTaskStatePerformance measured ([31m0.256[0m seconds)
+[32;1m✓[0m testTogglingTaskStatePerformance ([31m4.543[0m seconds)
+[32;1m✓[0m testUndoTaskToggleOnDeepTree (0.003 seconds)
+[39;1mMNCTaskPaperExporterTests[0m
+[32;1m✓[0m testTaskPaperExport ([31m0.108[0m seconds)
+[32;1m✓[0m testTaskPaperExportWithOmniFocusConfiguration ([31m0.104[0m seconds)
+[39;1mMNCTaskPaperImporterTests[0m
+[32;1m✓[0m testInlineTags ([33m0.033[0m seconds)
+[32;1m✓[0m testNotes ([33m0.031[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.032[0m seconds)
+[32;1m✓[0m testStructure ([33m0.036[0m seconds)
+[32;1m✓[0m testTasks ([33m0.032[0m seconds)
+[39;1mMNCTextBundleExporterTests[0m
+[32;1m✓[0m testBundleContent ([31m0.154[0m seconds)
+[39;1mMNCTextBundleImporterTests[0m
+[32;1m✓[0m testExportImportRoundTrip ([31m0.472[0m seconds)
+[32;1m✓[0m testImportOfTextBundleFile ([31m0.121[0m seconds)
+[39;1mMNCTextExporterTests[0m
+[32;1m✓[0m testNodeOrderOfPlainTextExport ([31m0.202[0m seconds)
+[39;1mMNCTextOutlineImporterTests[0m
+[31m✗[0m testPasteboard, failed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x60000184dfb0> was mutated while being enumerated."
+[32;1m✓[0m testPlainTextImport ([31m0.688[0m seconds)
+[39;1mMNCTheme2to3MigrationTests[0m
+[32;1m✓[0m testPartialNodeStyleWithColor (0.011 seconds)
+[32;1m✓[0m testPartialNodeStyleWithNode (0.011 seconds)
+[32;1m✓[0m testThatThemeUpgradeAndDowngradeResultsInOriginalTheme (0.016 seconds)
+[39;1mMNCThemeDataSourceTests[0m
+[32;1m✓[0m testThemeOrder (0.005 seconds)
+[39;1mMNCThemeManagerTests[0m
+[32;1m✓[0m testAddTheme (0.023 seconds)
+[32;1m✓[0m testRemoveTheme (0.022 seconds)
+[32;1m✓[0m testStandardThemes (0.001 seconds)
+[39;1mMNCThingsExporterTests[0m
+[32;1m✓[0m testExportURLGenertion ([31m0.156[0m seconds)
+[32;1m✓[0m testJSONDataExport ([31m0.154[0m seconds)
+[39;1mMNCUserIntentValidatorTests[0m
+[32;1m✓[0m testArrowKeyCommands (0.011 seconds)
+[32;1m✓[0m testAttachmentIntents ([31m0.186[0m seconds)
+[32;1m✓[0m testBalanceIntents (0.017 seconds)
+[32;1m✓[0m testBeginTextEditingOfConnectionIntent (0.013 seconds)
+[32;1m✓[0m testCenterMainNodeIntent (0.003 seconds)
+[32;1m✓[0m testChangeNodeOrderArrowKeyCommands (0.012 seconds)
+[32;1m✓[0m testCommitUnwiredConnectionIntent (0.004 seconds)
+[32;1m✓[0m testCopyIntent (0.007 seconds)
+[32;1m✓[0m testCreateConnectionIntent (0.009 seconds)
+[32;1m✓[0m testCreateNewNodeIntents ([33m0.074[0m seconds)
+[32;1m✓[0m testCycleBackwardIntent (0.003 seconds)
+[32;1m✓[0m testCycleForwardIntent (0.003 seconds)
+[32;1m✓[0m testDeleteIntent (0.004 seconds)
+[32;1m✓[0m testDetachNodeIntent (0.018 seconds)
+[32;1m✓[0m testDuplicateIntent (0.008 seconds)
+[32;1m✓[0m testEditNotesIntent (0.012 seconds)
+[32;1m✓[0m testExitDocumentIntent (0.012 seconds)
+[32;1m✓[0m testFoldIntent (0.009 seconds)
+[32;1m✓[0m testFontIntents ([33m0.029[0m seconds)
+[32;1m✓[0m testFullscreenIntent (0.009 seconds)
+[32;1m✓[0m testMoveNodeArrowKeyCommands (0.007 seconds)
+[32;1m✓[0m testNewMainNodeIntent (0.006 seconds)
+[32;1m✓[0m testNewParentNodeIntent (0.025 seconds)
+[32;1m✓[0m testNodeTextEditing (0.013 seconds)
+[32;1m✓[0m testOpenLinkIntent ([31m1.068[0m seconds)
+[32;1m✓[0m testPanIntents (0.006 seconds)
+[32;1m✓[0m testPasteIntent (0.009 seconds)
+[32;1m✓[0m testPrinterOptionsIntent (0.007 seconds)
+[32;1m✓[0m testRedoIntent (0.012 seconds)
+[32;1m✓[0m testReorganizeNodesIntent (0.009 seconds)
+[32;1m✓[0m testResetCrossConnectionWaypointIntent (0.012 seconds)
+[32;1m✓[0m testResetSelectionModeIntent (0.006 seconds)
+[32;1m✓[0m testSharingIntent (0.007 seconds)
+[32;1m✓[0m testShowInspectorIntents (0.020 seconds)
+[32;1m✓[0m testShowIntents (0.021 seconds)
+[32;1m✓[0m testShowLinkInputPanelIntent (0.006 seconds)
+[32;1m✓[0m testSimpleNodesIntents (0.012 seconds)
+[32;1m✓[0m testSingleObjectIntents (0.009 seconds)
+[32;1m✓[0m testSortNodesAlphabeticallyIntent (0.014 seconds)
+[32;1m✓[0m testSortNodesByTaskStateIntent (0.011 seconds)
+[32;1m✓[0m testStyleIntents (0.008 seconds)
+[32;1m✓[0m testToggleIntents (0.006 seconds)
+[32;1m✓[0m testUndoIntent (0.015 seconds)
+[32;1m✓[0m testUnfolAllNodesIntent (0.009 seconds)
+[32;1m✓[0m testUnfoldOneLevel (0.014 seconds)
+[32;1m✓[0m testZoomInIntent (0.003 seconds)
+[32;1m✓[0m testZoomOutIntent (0.003 seconds)
+[32;1m✓[0m testZoomToActualSizeIntent (0.006 seconds)
+[32;1m✓[0m testZoomToFitIntent (0.003 seconds)
+[39;1mMNCXMindImporterTests[0m
+[32;1m✓[0m testBackgroundColor ([31m0.167[0m seconds)
+[32;1m✓[0m testContent ([31m0.149[0m seconds)
+[32;1m✓[0m testCrossConnections ([31m0.149[0m seconds)
+[32;1m✓[0m testLinks ([31m0.148[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([31m0.149[0m seconds)
+[32;1m✓[0m testStructure ([31m0.147[0m seconds)
+[39;1mMNCXMindStyleImporterTest[0m
+[32;1m✓[0m testBorder ([31m0.482[0m seconds)
+[32;1m✓[0m testBorderLineWidth ([31m0.477[0m seconds)
+[32;1m✓[0m testColor ([31m0.487[0m seconds)
+[32;1m✓[0m testCrossConnectionStyle ([31m0.466[0m seconds)
+[39;1mMNCZoomingCalculatorTests[0m
+[32;1m✓[0m testCalculatorZoomIn (0.001 seconds)
+[32;1m✓[0m testCalculatorZoomOut (0.000 seconds)
+[32;1m✓[0m testCalculatorZoomScaleEqual (0.000 seconds)
+[32;1m✓[0m testDifferentInsets (0.000 seconds)
+[39;1mMNCiThoughtsImporterTests[0m
+[32;1m✓[0m testBoundariesV4 ([31m0.240[0m seconds)
+[32;1m✓[0m testCrossConnections ([31m0.828[0m seconds)
+[32;1m✓[0m testCrossConnectionsV3 ([31m0.193[0m seconds)
+[32;1m✓[0m testCrossConnectionsV4 ([31m0.231[0m seconds)
+[32;1m✓[0m testHyperlinks ([31m0.845[0m seconds)
+[32;1m✓[0m testHyperlinksV3 ([31m0.198[0m seconds)
+[32;1m✓[0m testHyperlinksV4 ([31m0.233[0m seconds)
+[32;1m✓[0m testImport ([31m0.841[0m seconds)
+[32;1m✓[0m testImportV3 ([31m0.195[0m seconds)
+[32;1m✓[0m testImportV4 ([31m0.227[0m seconds)
+[32;1m✓[0m testLayoutStyle ([31m0.831[0m seconds)
+[32;1m✓[0m testLayoutStyleV3 ([31m0.847[0m seconds)
+[32;1m✓[0m testLineTypeV4 ([31m0.226[0m seconds)
+[32;1m✓[0m testNodeAlignment ([31m0.835[0m seconds)
+[32;1m✓[0m testNodeAlignmentV3 ([31m0.197[0m seconds)
+[32;1m✓[0m testNodeAlignmentV4 ([31m0.231[0m seconds)
+[32;1m✓[0m testNodeFormatting ([31m0.828[0m seconds)
+[32;1m✓[0m testNodeFormattingV3 ([31m0.192[0m seconds)
+[32;1m✓[0m testNodeFormattingV4 ([31m0.227[0m seconds)
+[32;1m✓[0m testNodeText ([31m0.895[0m seconds)
+[32;1m✓[0m testNodeTextFormatting ([31m0.869[0m seconds)
+[32;1m✓[0m testNodeTextV3 ([31m0.199[0m seconds)
+[32;1m✓[0m testNodeTextV4 ([31m0.228[0m seconds)
+[32;1m✓[0m testNotes ([31m0.822[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([31m0.836[0m seconds)
+[32;1m✓[0m testNumberOfNodesV3 ([31m0.200[0m seconds)
+[32;1m✓[0m testNumberOfNodesV4 ([31m0.231[0m seconds)
+[32;1m✓[0m testTasks ([31m0.864[0m seconds)
+[39;1mMNColorTests[0m
+[32;1m✓[0m testBlackWhiteComplementColor (0.001 seconds)
+[32;1m✓[0m testColorComponentRetrieval (0.000 seconds)
+[32;1m✓[0m testDarkenedColor (0.000 seconds)
+[32;1m✓[0m testDerivedColor (0.000 seconds)
+[32;1m✓[0m testLightenedColor (0.000 seconds)
+[32;1m✓[0m testPropertyRepInit (0.000 seconds)
+[32;1m✓[0m testRGBComplementColor (0.001 seconds)
+[32;1m✓[0m testWebColorString3Init (0.001 seconds)
+[32;1m✓[0m testWebColorString6Init (0.001 seconds)
+[32;1m✓[0m testWebColorString8Init (0.000 seconds)
+[39;1mMNTDocumentControllerTests[0m
+[32;1m✓[0m testCreateNewDocument (0.000 seconds)
+[32;1m✓[0m testCreateNewDocumentInFolder (0.000 seconds)
+[32;1m✓[0m testCreateNewDocumentInFolderWithInvalidName (0.000 seconds)
+[32;1m✓[0m testRenameDocument (0.000 seconds)
+[32;1m✓[0m testURLCreation (0.001 seconds)
+[39;1mMNTRecentDocumentControllerTests[0m
+[32;1m✓[0m testDelegateCalls (0.012 seconds)
+[32;1m✓[0m testEqualURLs (0.008 seconds)
+[32;1m✓[0m testNumberOfDocumentsToTrack (0.017 seconds)
+[32;1m✓[0m testPersistence (0.010 seconds)
+[32;1m✓[0m testRemoval (0.005 seconds)
+[39;1mMNTReviewDisplayLogicTests[0m
+[32;1m✓[0m testFailureAppNotBought ([33m0.029[0m seconds)
+[32;1m✓[0m testFailureNotEnoughDocuments (0.007 seconds)
+[32;1m✓[0m testFailureNotEnoughtAppLaunches (0.025 seconds)
+[32;1m✓[0m testSucess ([33m0.027[0m seconds)
+[39;1mMNTextTests[0m
+[32;1m✓[0m testApplyStyle (0.004 seconds)
+[32;1m✓[0m testApplyStyleInRange (0.002 seconds)
+[32;1m✓[0m testEditing (0.001 seconds)
+[32;1m✓[0m testEmptyInit (0.001 seconds)
+[32;1m✓[0m testFindString (0.001 seconds)
+[32;1m✓[0m testInit (0.001 seconds)
+[32;1m✓[0m testSavingAndLoadingOfStringWithSpecialControlCharacters (0.001 seconds)
+[32;1m✓[0m testSetString (0.001 seconds)
+[32;1m✓[0m testTextWithAttributes (0.001 seconds)
+[32;1m✓[0m testTextWithFont (0.001 seconds)
+[32;1m✓[0m testTextWithFontMonospaced (0.003 seconds)
+[39;1mMorphingTests[0m
+[32;1m✓[0m testNormalization (0.001 seconds)
+[33m◷[0m testPerformance measured ([31m0.180[0m seconds)
+[32;1m✓[0m testPerformance ([31m2.369[0m seconds)
+[32;1m✓[0m testSimpleInsert (0.001 seconds)
+[32;1m✓[0m testSimpleMatch (0.001 seconds)
+[32;1m✓[0m testSimpleMorph (0.000 seconds)
+[39;1mNSAttributedStringMarkdownTests[0m
+[32;1m✓[0m testBoldItalic (0.001 seconds)
+[32;1m✓[0m testBoldMarkdownConversion (0.001 seconds)
+[32;1m✓[0m testCombiningAttributes (0.001 seconds)
+[32;1m✓[0m testItalicMarkdownConversion (0.001 seconds)
+[32;1m✓[0m testLinkConversion (0.001 seconds)
+[32;1m✓[0m testParagraphs (0.001 seconds)
+[32;1m✓[0m testPlainTextConversion (0.001 seconds)
+[32;1m✓[0m testStrikethroughConversion (0.001 seconds)
+[39;1mNSRangeSwiftTests[0m
+[32;1m✓[0m testFullRange (0.000 seconds)
+[32;1m✓[0m testSubStringFromIndex (0.001 seconds)
+[32;1m✓[0m testSubStringFromRange (0.000 seconds)
+[39;1mSSWZipTests[0m
+[32;1m✓[0m testAddCompressedEntry ([33m0.049[0m seconds)
+[32;1m✓[0m testAddSymbolicLink ([33m0.026[0m seconds)
+[32;1m✓[0m testAddUncompressedEntry ([33m0.028[0m seconds)
+[32;1m✓[0m testCreateCompressedArchive ([33m0.026[0m seconds)
+[32;1m✓[0m testCreateNestedDirectoryStrucutre (0.023 seconds)
+[32;1m✓[0m testCreateUncompressedArchive (0.023 seconds)
+[32;1m✓[0m testDetectionOfUnspportedFormatFeatures ([33m0.076[0m seconds)
+[32;1m✓[0m testLastModFileDate ([33m0.032[0m seconds)
+[32;1m✓[0m testLastModFileTime (0.024 seconds)
+[32;1m✓[0m testNonUnixOSTypes (0.017 seconds)
+[32;1m✓[0m testPosixPermissions ([33m0.032[0m seconds)
+[32;1m✓[0m testRemoveCompressedEntry ([33m0.073[0m seconds)
+[32;1m✓[0m testRemoveUncompressedEntry ([33m0.055[0m seconds)
+[32;1m✓[0m testUnzipCompressedEntryToData ([33m0.054[0m seconds)
+[32;1m✓[0m testUnzipCompressedEntryToURL ([33m0.032[0m seconds)
+[32;1m✓[0m testUnzipCompressedFolderArchive (0.013 seconds)
+[33m◷[0m testUnzipCompressedFolderEntries measured (0.003 seconds)
+[32;1m✓[0m testUnzipCompressedFolderEntries ([31m0.304[0m seconds)
+[32;1m✓[0m testUnzipItemAtURL ([33m0.065[0m seconds)
+[32;1m✓[0m testUnzipItemAtURLErrorConditions (0.013 seconds)
+[32;1m✓[0m testUnzipUncompressedEntryToData ([33m0.049[0m seconds)
+[32;1m✓[0m testUnzipUncompressedEntryToURL ([33m0.034[0m seconds)
+[32;1m✓[0m testUnzipUncompressedFolderArchive (0.014 seconds)
+[32;1m✓[0m testUnzipUncompressedFolderEntries ([33m0.040[0m seconds)
+[33m◷[0m testZipDirectoryContentsAtURL measured ([31m0.300[0m seconds)
+[32;1m✓[0m testZipDirectoryContentsAtURL ([31m3.307[0m seconds)
+[32;1m✓[0m testZipDirectoryContentsAtURLErrorConditions (0.014 seconds)
+[39;1mWatchDocumentExporterTests[0m
+[32;1m✓[0m testExample (0.011 seconds)
+[39;1mWatchTransferStatusTests[0m
+[32;1m✓[0m testWatchTransferPersistence (0.003 seconds)
+
+
+MindNode_for_iOS_Tests.MNCTextOutlineImporterTests
+testPasteboard, [31mfailed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x60000184dfb0> was mutated while being enumerated."[0m
+[36m<unknown>:0[0m
+
+
+[31m	 Executed 509 tests, with 1 failure (1 unexpected) in 188.178 (188.426) seconds
+[0m
+Failing tests:
+MNCTextOutlineImporterTests.testPasteboard()
+** TEST FAILED **
+[14:57:45]: [31mExit status: 65[0m
++--------------------+-----+
+|       Test Results       |
++--------------------+-----+
+| Number of tests    | 596 |
+| Number of failures | [31m1[0m   |
++--------------------+-----+
+
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                            [33mLane Context[0m                                                                                            |
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| PLATFORM_NAME              | ios                                                                                                                                                                   |
+| LANE_NAME                  | ios staticAnalyze                                                                                                                                                     |
+| SCAN_DERIVED_DATA_PATH     | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq                                                                        |
+| SCAN_GENERATED_PLIST_FILES | ["/Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Logs/Test/5D91A1B0-CCFD-4594-A90B-8D90631D0E2C_TestSummaries.plist"] |
+| SCAN_GENERATED_PLIST_FILE  | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Logs/Test/5D91A1B0-CCFD-4594-A90B-8D90631D0E2C_TestSummaries.plist     |
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+[14:57:45]: [31mTests have failed[0m
+
++------+----------------------------+-------------+
+|                [32mfastlane summary[0m                 |
++------+----------------------------+-------------+
+| Step | Action                     | Time (in s) |
++------+----------------------------+-------------+
+| 1    | Verifying fastlane version | 0           |
+| 2    | clear_derived_data         | 2           |
+| 💥   | [31mscan[0m                       | 543         |
++------+----------------------------+-------------+
+
+[14:57:45]: [31mfastlane finished with errors[0m
+[31m
+[!] Tests have failed[0m
+
+#######################################################################
+# fastlane 2.89.0 is available. You are on 2.79.0.
+# You should use the latest version.
+# Please update using `bundle update fastlane`.
+#######################################################################
+
+[32m2.89.0 Improvements[0m
+* [action] Make sure get_version_number targets respond to test_target_type? (#12212) via Josh Holtz
+* [action] Make enable_automatic_code_signing for all configurations (#12187) via Nicolas Braun
+* [produce]Use correct spelling of icloud service in product/service.rb (#12134) via Jakub Knejzlík
+* [action] Add Support for Registering Mac Devices on Apple Developer Portal (#11978) via Baumchen
+* [spaceship] Spaceship delete testflight groups (#12111) via Kenneth Wong
+* [produce] Enable set 'NFC Tag Reading' at 'fastlane produce' cli. (#12179) (#12201) via Kazuhide Takahashi
+* [frameit] frameit documentation describes all parameters from the Framefile (#11662) via funnel20
+* [supply] Clarify difference between SUPPLY_JSON_KEY and SUPPLY_JSON_KEY_DATA via Aaron Brager
+* [action] added custom api_url option to testfairy (#12153) via Josh Holtz
+
+[32m2.88.0 Improvements[0m
+* [action] Fix crashlytics to not autoload gsp_path if api_token is set (#12176) via Josh Holtz
+* Improve error message when specified scheme is not found (#12182) via Cédric Luthi
+* [action] Support checking remote git tags existence (#11675) via Takeru Chuganji
+* Use Android environment to find adb (don't just rely on it being in PATH) (#12168) via Adam Cohen-Rose
+* [snapshot] Make sure matched window has a non-empty frame (#12174) via François Pradel
+* [swift] Fixes string return value and shows all lanes (even without description) (#12171) via Josh Holtz
+* [scan] Default skip_build to true in Scanfile template (#12162) via Aaron Brager
+
+[32m2.87.0 Lots of action fixes and xcodeproj gem update[0m
+* [supply] Added internal track (#12128) via Josh Holtz
+* [Action] get_latest_version handles $(SRCROOT) and tries to get target that isn't test (#12138) via Josh Holtz
+* [Action] app_store_build_number converts return to int if possible (#12148) via Josh Holtz
+* Workspace contained schemes now get loaded (#12147) via Lou Franco
+* Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting iOS projects (#12142) via Hiroyuki Morita
+* [Action] Add use_bundle_exec option to pod_push action (#11947) via Nicolas Braun
+* [match] Write Match encrypted files in binary mode to avoid UndefinedConversion error (#12112) via Michael Smith
+* [Action] Fix a bug that upload_symbols_to_crashlytics fails if path has a space (#12098) via Takeru Chuganji
+
+[32mTo see all new releases, open https://github.com/fastlane/fastlane/releases[0m
+
+[32mPlease update using `bundle update fastlane`[0m
+14:57:48 [[0;32mMESSAGE[0;0m] Platform.swift [Line: 23]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+14:57:48 [[0;32mMESSAGE[0;0m] ColorDragController.swift [Line: 26]  Weak Delegate Violation: Delegates should be weak to avoid reference cycles. (weak_delegate)
+14:57:48 [[0;32mMESSAGE[0;0m] MNCBoundaryMorphTests.swift [Line: 52]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+14:57:48 [[0;32mMESSAGE[0;0m] Data+Serialization.swift [Line: 60]  'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'
+14:57:48 [[0;32mMESSAGE[0;0m] MNTUserIntentValidatorTests.swift [Line: 569]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+14:57:48 [[0;32mMESSAGE[0;0m] MNTUserIntentValidatorTests.swift [Line: 645]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+14:57:48 [[0;32mMESSAGE[0;0m] Reachability.swift [Line: 136]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+14:57:48 [[0;32mMESSAGE[0;0m] ✗ testPasteboard
+14:57:48 [[0;33mWARNING[0;0m] Fastlane exit code: 65
+14:57:48 [[0;32mMESSAGE[0;0m] --------------------- Summary ---------------------
+14:57:48 [[0;32mMESSAGE[0;0m] Ignored Keywords: todo, -Wpragma, BITCrashManager, deprecated in iOS 11.0, type-check (limit:
+14:57:48 [[0;31m ERROR [0;0m] 7. Static Analyzer Warnings
+14:57:48 [[0;31m ERROR [0;0m] 1. Unit Test Errors
+14:57:48 [[0;31m ERROR [0;0m] Static Analyzer failed

--- a/CallistoTest/mac_build_8731.log
+++ b/CallistoTest/mac_build_8731.log
@@ -1,0 +1,2727 @@
+~~~ Preparing build folder
+[90m$[0m mkdir -p "/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app"
+[90m$[0m cd "/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app"
+[90m$[0m ssh-keyscan "github.com" >> "/Users/administrator/.ssh/known_hosts"
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+[90m$[0m git remote set-url origin "git@github.com:company/app.git"
+[90m$[0m git clean "-fdq"
+[90m$[0m git submodule foreach --recursive git clean "-fdq"
+[90m$[0m git fetch -v origin "refs/pull/3069/head"
+From github.com:company/app
+ * branch                  refs/pull/3069/head -> FETCH_HEAD
+[90m$[0m git checkout -f "42839f3ce91a4f3a339286827ac6f16affca3f47"
+HEAD is now at 42839f3ce9... Update layout when rewiring
+[90m$[0m git submodule sync --recursive
+[90m$[0m git submodule update --init --recursive
+[90m$[0m git submodule foreach --recursive git reset --hard
+~~~ Running command
+[90m$[0m #!/bin/bash
+
+if [ "$(ls .scripts/buildkite | grep mac_tests.sh)" ]
+then ./.scripts/buildkite/mac_tests.sh
+else
+echo "----------------------------------"
+echo "##  BuildkiteScript not found   ##"
+echo "##    fallback to old style     ##"
+echo "----------------------------------"
+bundle install --path ~/gems
+bundle exec fastlane mac test
+fi
+Using rake 12.3.0
+Using CFPropertyList 2.3.6
+Using concurrent-ruby 1.0.5
+Using i18n 0.9.3
+Using minitest 5.11.2
+Using thread_safe 0.3.6
+Using tzinfo 1.2.4
+Using activesupport 4.2.10
+Using public_suffix 2.0.5
+Using addressable 2.5.2
+Using babosa 1.0.2
+Using bundler 1.16.0
+Using claide 1.0.2
+Using colored2 3.1.2
+Using cork 0.3.0
+Using nap 1.1.0
+Using open4 1.3.4
+Using claide-plugins 0.9.2
+Using fuzzy_match 2.0.4
+Using cocoapods-core 1.3.1
+Using cocoapods-deintegrate 1.0.2
+Using cocoapods-downloader 1.1.3
+Using cocoapods-plugins 1.0.0
+Using cocoapods-search 1.0.0
+Using cocoapods-stats 1.0.0
+Using netrc 0.11.0
+Using cocoapods-trunk 1.3.0
+Using cocoapods-try 1.1.0
+Using escape 0.0.4
+Using fourflusher 2.0.1
+Using gh_inspector 1.0.3
+Using molinillo 0.5.7
+Using ruby-macho 1.1.0
+Using nanaimo 0.2.3
+Using xcodeproj 1.5.4
+Using cocoapods 1.3.1
+Using redcarpet 3.4.0
+Using cocoapods-acknowledgements 1.1.2
+Using colored 1.2
+Using highline 1.7.10
+Using commander-fastlane 4.4.5
+Using multipart-post 2.0.0
+Using faraday 0.14.0
+Using faraday-http-cache 1.3.1
+Using git 1.3.0
+Using kramdown 1.16.2
+Using no_proxy_fix 0.1.2
+Using sawyer 0.8.1
+Using octokit 4.8.0
+Using unicode-display_width 1.3.0
+Using terminal-table 1.8.0
+Using danger 5.5.7
+Using thor 0.20.0
+Using danger-swiftlint 0.12.1
+Using declarative 0.0.10
+Using declarative-option 0.1.0
+Using unf_ext 0.0.7.4
+Using unf 0.1.4
+Using domain_name 0.5.20170404
+Using dotenv 2.2.1
+Using excon 0.60.0
+Using http-cookie 1.0.3
+Using faraday-cookie_jar 0.0.6
+Using faraday_middleware 0.12.2
+Using fastimage 2.1.1
+Using jwt 2.1.0
+Using little-plugger 1.1.4
+Using multi_json 1.13.1
+Using logging 2.2.2
+Using memoist 0.16.0
+Using os 0.9.6
+Using signet 0.8.1
+Using googleauth 0.6.2
+Using httpclient 2.8.3
+Using mime-types-data 3.2016.0521
+Using mime-types 3.1
+Using uber 0.1.0
+Using representable 3.0.4
+Using retriable 3.1.1
+Using google-api-client 0.13.6
+Using json 2.1.0
+Using mini_magick 4.5.1
+Using multi_xml 0.6.0
+Using plist 3.4.0
+Using rubyzip 1.2.1
+Using security 0.1.3
+Using slack-notifier 2.3.2
+Using terminal-notifier 1.8.0
+Using tty-screen 0.6.4
+Using tty-cursor 0.5.0
+Using tty-spinner 0.8.0
+Using word_wrap 1.0.0
+Using rouge 2.0.7
+Using xcpretty 0.2.8
+Using xcpretty-travis-formatter 1.0.0
+Using fastlane 2.79.0
+[32mBundle complete! 6 Gemfile dependencies, 96 gems now installed.[0m
+[32mBundled gems are installed into `/Users/administrator/gems`[0m
+[17:29:00]: [32m----------------------------------------[0m
+[17:29:00]: [32m--- Step: Verifying fastlane version ---[0m
+[17:29:00]: [32m----------------------------------------[0m
+[17:29:00]: Your fastlane version 2.79.0 matches the minimum requirement of 1.37.0  ✅
+[17:29:00]: [33mName of the lane 'build_app' is already taken by the action named 'build_app'[0m
+[17:29:00]: [32mDriving the lane 'mac staticAnalyze' 🚀[0m
+[17:29:00]: [32m--------------------------------[0m
+[17:29:00]: [32m--- Step: clear_derived_data ---[0m
+[17:29:00]: [32m--------------------------------[0m
+[17:29:00]: Derived Data path located at: /Users/administrator/Library/Developer/Xcode/DerivedData
+[17:29:02]: [32mSuccessfully cleared Derived Data ♻️[0m
+[17:29:02]: [32m------------------[0m
+[17:29:02]: [32m--- Step: scan ---[0m
+[17:29:02]: [32m------------------[0m
+[17:29:02]: [36m$ xcodebuild -list -workspace app.xcworkspace[0m
+[17:29:04]: [36m$ xcodebuild -showBuildSettings -workspace app.xcworkspace -scheme app\ for\ macOS[0m
+[17:29:07]: [33mIt's not recommended to set the `destination` value directly[0m
+[17:29:07]: [33mInstead use the other options available in `fastlane scan --help`[0m
+[17:29:07]: [33mUsing your value 'platform=macOS' for now[0m
+[17:29:07]: [33mbecause I trust you know what you're doing...[0m
+[17:29:07]: [36m$ xcodebuild -list -workspace app.xcworkspace[0m
+[17:29:09]: [36m$ xcodebuild -showBuildSettings -workspace app.xcworkspace -scheme app\ for\ macOS[0m
+[17:29:12]: [33mIt's not recommended to set the `destination` value directly[0m
+[17:29:12]: [33mInstead use the other options available in `fastlane scan --help`[0m
+[17:29:12]: [33mUsing your value 'platform=macOS' for now[0m
+[17:29:12]: [33mbecause I trust you know what you're doing...[0m
+
++------------------------+-------------------------------------------------------------------------------------------------------------+
+|                                                       [32mSummary for scan 2.79.0[0m                                                        |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+| workspace              | app.xcworkspace                                                                                        |
+| scheme                 | app for macOS                                                                                          |
+| xcargs                 | CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze |
+| derived_data_path      | /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq              |
+| clean                  | false                                                                                                       |
+| skip_build             | false                                                                                                       |
+| output_directory       | ./fastlane/test_output                                                                                      |
+| output_types           | html,junit                                                                                                  |
+| buildlog_path          | ~/Library/Logs/scan                                                                                         |
+| include_simulator_logs | false                                                                                                       |
+| open_report            | false                                                                                                       |
+| skip_slack             | false                                                                                                       |
+| slack_only_on_failure  | false                                                                                                       |
+| use_clang_report_name  | false                                                                                                       |
+| fail_build             | true                                                                                                        |
+| xcode_path             | /Applications/Xcode.app                                                                                     |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+
+[17:29:12]: [36m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace app.xcworkspace -scheme app\ for\ macOS -destination 'platform=macOS' -derivedDataPath '/Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq' CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze build test | tee '/Users/administrator/Library/Logs/scan/app-app for macOS.log' | xcpretty  --report html --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/fastlane/test_output/report.html' --report junit --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/fastlane/test_output/report.junit' --report junit --output '/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/junit_report20180403-56018-1c9frnf'[0m
+[17:29:12]: ▸ [35mLoading...[0m
+[17:29:14]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-macOS [Debug][0m
+[17:29:14]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-macOS-dummy.m[0m
+[17:29:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[17:29:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[17:29:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging-macOS-dummy.m[0m
+[17:29:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m[0m
+[17:29:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m[0m
+[17:29:24]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-macOS.a[0m
+[17:29:24]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared macOS [Debug][0m
+[17:29:24]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:24]: [35m[33m▸[0m [39;1mProcessing[0m Shared-macOS-Info.plist[0m
+[17:29:24]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[17:29:31]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:29:31]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:29:31]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:29:31]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[17:29:37]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+Cocoa.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[17:29:38]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+macOS.swift[0m
+[17:29:43]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[17:29:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[17:29:48]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[17:29:48]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[17:29:48]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[17:29:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[17:29:48]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[17:29:48]: [35m[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m[0m
+[17:29:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m[0m
+[17:29:52]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m[0m
+[17:29:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[17:29:52]: [35m[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m[0m
+[17:29:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m[0m
+[17:29:52]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNDefer.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNGenericCopy.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m MNBoxing.h[0m
+[17:29:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto macOS [Debug][0m
+[17:29:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:53]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_macOS.h[0m
+[17:29:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-macOS [Debug][0m
+[17:29:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m cmark-macOS-dummy.m[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m blocks.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m buffer.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark-macOS-dummy.m[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m commonmark.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m html.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m inlines.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m iterator.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m latex.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m man.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m node.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m references.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m render.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m scanners.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m utf8.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m xml.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-macOS.a[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[17:29:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:53]: [35m[33m▸[0m [39;1mProcessing[0m Info-macOS.plist[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_macOS.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c[0m
+[17:29:53]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[17:29:53]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:29:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:29:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:53]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[17:29:53]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[17:29:53]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[17:29:53]: ▸ [35m[36m                                            ^[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[17:29:53]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[17:29:53]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[17:29:53]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-macOS [Debug][0m
+[17:29:53]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[17:29:53]: [35m[33m▸[0m [39;1mCompiling[0m box2d-macOS-dummy.m[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp[0m
+[17:29:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2World.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp[0m
+[17:29:55]: [35m[33m▸[0m [39;1mAnalyzing[0m box2d-macOS-dummy.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-macOS.a[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-macOS [Debug][0m
+[17:29:56]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-macOS-dummy.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-macOS-dummy.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-macOS.a[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug][0m
+[17:29:56]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:56]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[17:29:56]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:29:56]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:29:56]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[17:29:56]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/SwiftyAshton/Sources/Ashton/AshtonHTMLWriter.swift:173:49: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:29:56]: ▸ [35mlet features = fontFeatures.flatMap { feature in[0m
+[17:29:56]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[17:29:56]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[17:29:56]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m Reachability/ReachabilityMac [Debug][0m
+[17:29:56]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:56]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[17:29:56]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[17:29:56]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[17:29:56]: ▸ [35m[36m                                                ^~~~~~~[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[17:29:56]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCopying[0m ReachabilityMac.h[0m
+[17:29:56]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/app Helper [Debug][0m
+[17:29:56]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m main.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m AppDelegate.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[17:29:56]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:29:56]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Helper.app[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/appQuickLookPlugIn [Debug][0m
+[17:29:56]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:56]: [35m[33m▸[0m [39;1mProcessing[0m appQuickLookPlugIn-Info.plist[0m
+[17:29:56]: [35m[33m▸[0m [39;1mPrecompiling[0m appQuickLookPlugIn/appQuickLookPlugIn-Prefix.pch[0m
+[17:29:56]: [35m[33m▸[0m [39;1mPrecompiling[0m appQuickLookPlugIn/appQuickLookPlugIn-Prefix.pch[0m
+[17:29:56]: [35m[33m▸[0m [39;1mPrecompiling[0m appQuickLookPlugIn/appQuickLookPlugIn-Prefix.pch[0m
+[17:29:56]: [35m[33m▸[0m [39;1mPrecompiling[0m appQuickLookPlugIn/appQuickLookPlugIn-Prefix.pch[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m GenerateThumbnailForURL.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m GeneratePreviewForURL.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[17:29:56]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m GenerateThumbnailForURL.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m GeneratePreviewForURL.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[17:29:56]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[17:29:56]: [35m[33m▸[0m [39;1mLinking[0m appQuickLookPlugIn[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCopying[0m InfoPlist.strings[0m
+[17:29:57]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m appQuickLookPlugIn.qlgenerator[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/appSpotlightImporter [Debug][0m
+[17:29:57]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:57]: [35m[33m▸[0m [39;1mProcessing[0m appSpotlightImporter-Info.plist[0m
+[17:29:57]: [35m[33m▸[0m [39;1mPrecompiling[0m appSpotlightImporter/appSpotlightImporter-Prefix.pch[0m
+[17:29:57]: [35m[33m▸[0m [39;1mPrecompiling[0m appSpotlightImporter/appSpotlightImporter-Prefix.pch[0m
+[17:29:57]: [35m[33m▸[0m [39;1mPrecompiling[0m appSpotlightImporter/appSpotlightImporter-Prefix.pch[0m
+[17:29:57]: [35m[33m▸[0m [39;1mPrecompiling[0m appSpotlightImporter/appSpotlightImporter-Prefix.pch[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m GetMetadataForFile.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m GetMetadataForFile.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mLinking[0m appSpotlightImporter[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCopying[0m appSpotlightImporter/schema.xml[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCopying[0m InfoPlist.strings[0m
+[17:29:57]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m appSpotlightImporter.mdimporter[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for macOS Tests [Debug][0m
+[17:29:57]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ macOS\ Tests-dummy.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ macOS\ Tests-dummy.m[0m
+[17:29:57]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ macOS\ Tests.a[0m
+[17:29:57]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing macOS [Debug][0m
+[17:29:57]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:29:57]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[17:29:57]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[17:29:58]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[17:29:59]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[17:30:01]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[17:30:02]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_macOS.h[0m
+[17:30:02]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[17:30:02]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/app Quick Entry [Debug][0m
+[17:30:02]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:30:02]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCopying[0m Resources/Colors[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m MNXQuickEntryPopoverViewController.xib[0m
+[17:30:02]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:30:02]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework[0m
+[17:30:02]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ Quick\ Entry.app[0m
+[17:30:02]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-app for macOS [Debug][0m
+[17:30:02]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:30:02]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ macOS-dummy.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-app\ for\ macOS-dummy.m[0m
+[17:30:02]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ macOS.a[0m
+[17:30:03]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/app for macOS [Debug][0m
+[17:30:03]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:30:03]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:30:03]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:30:28]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:30:28]: ▸ [35mlet childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }[0m
+[17:30:28]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[17:30:28]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:30:28]: ▸ [35mreturn supernode.subnodes.flatMap {[0m
+[17:30:28]: ▸ [35m[36m                                                                     ^~~~~~~[0m
+[17:30:28]: [35m[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch[0m
+[17:30:33]: [35m[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch[0m
+[17:30:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorViewController.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorClipView.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXNumberFormatter.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeView.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXappSingleFileExportViewController.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXKeyCommand.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineBaseCellView.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m NSView+LayoutConstraintFiltering.m[0m
+[17:30:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCFileLink.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m NSWindow+FullScreen.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextAlignmentValueTransformer.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNCollectionView.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m NSString+UUID.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode.m[0m
+[17:30:37]: [35m[33m▸[0m [39;1mCompiling[0m MNDefaults.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeView.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXClipView.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineRowView.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateNodeKnobState.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadDocumentViewController.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXOpenBrowserSharingService.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell+Bindings.m[0m
+[17:30:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXShadowSeparatorContentView.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteIndicatorButton.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedControl.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineDataSource.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNCNote.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverManager.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontManager.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserItem.m[0m
+[17:30:39]: [35m[33m▸[0m [39;1mCompiling[0m NSPopover+MNDetach.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument+Scripting.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyapp.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathView.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m NSImage+MNAdditions.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.m[0m
+[17:30:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXSheetWindowController.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedControl.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXPageSliderCell.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCContent.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Alignment.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleController.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m NSSegmentedControl+MNAdditions.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m NSFontDescriptor+Convenience.m[0m
+[17:30:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCAsset.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCDevice.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeInteractionState.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNVector.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantButtonCell.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m[0m
+[17:30:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXAppDelegate.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXDraggingOperationState.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXLayoutManager.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappEditAccountWindowController.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXQuickLookController.m[0m
+[17:30:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasView.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateCrossConnectionKnobState.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Insertion.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.m[0m
+[17:30:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXSidebarContainer.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachment.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXSwitch.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.m[0m
+[17:30:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXSingleAxisScrollView.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCExporter.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachableButtonCell.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m NSApplication+LaunchServices.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageView.m[0m
+[17:30:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCText.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m NSEvent+MNAdditions.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCTask.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeAccessoryButton.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m NSCursor+ObjectManipulationCursors.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorSectionViewController.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m NSPasteboard+Additions.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.m[0m
+[17:30:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasInteractionState.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m NSBezierPath+MNCGPathRef.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesView.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXFoldingIndicatorButton.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXThingsAppleScriptExporter.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+MNPlatformCompatibility.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorSwatchView.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m[0m
+[17:30:48]: [35m[33m▸[0m [39;1mCompiling[0m NSSharingService+MNXAdditions.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXSanitizingTextView.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasView.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadCompleteViewController.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorGridView.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarContainerView.m[0m
+[17:30:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoOverlayView.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyappPreferencesViewController.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m NSString+Paths.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNError.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarButtonContainerView.m[0m
+[17:30:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXRubberBandView.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineTableView.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasPrintView.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersSharingService.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareLinkViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m NSScrollView+ScrollingAdditions.m[0m
+[17:30:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXTaskButton.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextFinderClient.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArt.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m NSFont+Convenience.m[0m
+[17:30:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyappDocument.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNZooming.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXFunctions.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineCellView.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSearchCellView.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCKnobView.m[0m
+[17:30:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareWindowController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasViewController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedCell.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Animation.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+NodeActions.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXScrollView.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappRegisterWindowController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachedTextField.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportViewController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXSearchField.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionState.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoLaunchWindowController.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserCell.m[0m
+[17:30:54]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNViewActions.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXCreateCrossConnectionState.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXDragAndDropImageView.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCappExporter.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m NSGraphicsContext+MNAdditions.m[0m
+[17:30:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXResizableScrollView.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedCell.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextView.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserView.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeWellButton.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextEditor.m[0m
+[17:30:56]: [35m[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCycleNode.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXView.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.m[0m
+[17:30:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPDFExporter.m[0m
+[17:30:58]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorViewController.m[0m
+[17:30:58]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorClipView.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+ObjectsConvenience.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode+MNPropertyRepresentation.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNumberFormatter.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDateFormatter+MNAdditions.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeView.m[0m
+[17:31:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXappSingleFileExportViewController.m[0m
+[17:31:08]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme.m[0m
+[17:31:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXKeyCommand.m[0m
+[17:31:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument.m[0m
+[17:31:09]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Components.m[0m
+[17:31:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineBaseCellView.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+LayoutConstraintFiltering.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersSyncController.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExtractCustomThemeWindowController.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFileLink.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSWindow+FullScreen.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineViewController.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextAlignmentValueTransformer.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionView.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPastePersistentManager.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBranchRenderer.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[17:31:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSIndexPath+MNCollectionView.m[0m
+[17:31:11]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutControllerManager.m[0m
+[17:31:11]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+UUID.m[0m
+[17:31:11]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode.m[0m
+[17:31:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNDefaults.m[0m
+[17:31:22]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+Stack.m[0m
+[17:31:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCShapeStyle.m[0m
+[17:31:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasView.m[0m
+[17:31:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeView.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+MNAdditions.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXClipView.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCColorValueTransformer.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxy.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTranslateNodeController.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineRowView.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXShortcutsPreferencesViewController.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTranslateNodeKnobState.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocument.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappUploadDocumentViewController.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOpenBrowserSharingService.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorWell+Bindings.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelectionController.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXShadowSeparatorContentView.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMarkdownExporter.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindParser.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNoteIndicatorButton.m[0m
+[17:31:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedControl.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineDataSource.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNote.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToOmniFocusViewController.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverManager.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNAdditions.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFontManager.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserItem.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m NSPopover+MNDetach.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageExporter.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocument+Scripting.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseTextExporter.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyapp.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathView.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m NSImage+MNAdditions.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineLayouter.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSettingsViewController.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeRenderer.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSheetWindowController.m[0m
+[17:31:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorWell.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedControl.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+CIELAB.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPageSliderCell.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCContent.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Alignment.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleController.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController+box2dInterface.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFontSectionViewController.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleValue.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextView+MNAdditions.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText+MNPropertyRepresentation.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSegmentedControl+MNAdditions.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSFontDescriptor+Convenience.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFontStyle.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionKnobView.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerComposedDataSource.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+MNCProperties.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAsset.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[17:31:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDevice.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMainThreadHangDetector.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeInteractionState.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeStyle.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathStyle.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNVector.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantButtonCell.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentImageManager.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAppDelegate.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDraggingOperationState.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseParser.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMigrationManager.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXLayoutManager.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappEditAccountWindowController.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXQuickLookController.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasView.m[0m
+[17:31:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesWindowController.m[0m
+[17:31:27]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCConvexHullController.m[0m
+[17:31:27]: [35m[33m▸[0m [39;1mAnalyzing[0m NSTextAttachment+MNAdditions.m[0m
+[17:31:27]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVParser.m[0m
+[17:31:27]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCIThoughtsParser.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTranslateCrossConnectionKnobState.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+QueryParsing.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindExporter.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAboutWindowController.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Insertion.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPlainTextExporter.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXStyleInspectorViewController.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyController.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXGeneralPreferencesViewController.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineDefines.m[0m
+[17:31:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRichTextExporter.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSidebarContainer.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMindjetParser.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBaseDataSource.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSParagraphStyle+MNConvenience.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachment.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSwitch.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXContentInspectorViewController.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLExporter.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageAttachment.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUserGuideView.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCArrowStyle.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPrintAccessoryViewController.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSingleAxisScrollView.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSData+Convenience.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskSyncController.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCValueTransformerRegistration.m[0m
+[17:31:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCExporter.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAttachableButtonCell.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineTasksDataSource.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSApplication+LaunchServices.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme+Creation.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageView.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersViewController.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCloudShapeGenerator.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineSearchDataSource.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSEvent+MNAdditions.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTask.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeAccessoryButton.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSCursor+ObjectManipulationCursors.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorSectionViewController.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLParser.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineNodeCache.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableAttributedString+Convenience.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSPasteboard+Additions.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeBorderSectionViewController.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasInteractionState.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSBezierPath+MNCGPathRef.m[0m
+[17:31:38]: [35m[33m▸[0m [39;1mAnalyzing[0m CAAnimation+MNCompletionBlocks.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesView.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFoldingIndicatorButton.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXThingsAppleScriptExporter.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNoteSectionViewController.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInfoTextViewController.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPathStyleSectionViewController.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachmentRenderer.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m NSValue+MNPlatformCompatibility.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImagePickerViewController.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorSwatchView.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerContentDataSource.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSharingService+MNXAdditions.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSanitizingTextView.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSubselectionResizeKnobView.m[0m
+[17:31:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNImporting.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasView.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAnalyticsTracker.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappUploadCompleteViewController.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorGridView.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarContainerView.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionRenderer.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDemoOverlayView.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToThingsViewController.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMyappPreferencesViewController.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+Paths.m[0m
+[17:31:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNError.m[0m
+[17:31:41]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutManager.m[0m
+[17:31:41]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme1To2MigrationController.m[0m
+[17:31:41]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m[0m
+[17:31:41]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument4to5MigrationController.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetViewController.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarButtonContainerView.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNExporting.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFreemindExportViewController.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXRubberBandView.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageExportViewController.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineTableView.m[0m
+[17:31:49]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasPrintView.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasRenderer.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPDFExportViewController.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersSharingService.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAshtonValueTransformer.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMindMapSectionViewController.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappShareLinkViewController.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextExportViewController.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersExporter.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m NSScrollView+ScrollingAdditions.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTaskButton.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtAttachment.m[0m
+[17:31:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextOutlineParser.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+Convenience.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextFinderClient.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOPMLExportViewController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStrokeStyle.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverViewController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArt.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSFont+Convenience.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXLeadingSidebarTabController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyappDocument.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNZooming.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtSet.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeWellButton.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFunctions.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineCellView.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeShapeSectionViewController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVExporter.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseStyle.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSearchCellView.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCKnobView.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappShareWindowController.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskButton.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentObjectSavingManager.m[0m
+[17:31:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasViewController.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedCell.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Animation.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+NodeActions.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionStyle.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXScrollView.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyappRegisterWindowController.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAttachedTextField.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportViewController.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextController.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSearchField.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionState.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDemoLaunchWindowController.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserCell.m[0m
+[17:31:52]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[17:31:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelection.m[0m
+[17:31:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNViewActions.m[0m
+[17:31:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController+Selection.m[0m
+[17:31:56]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNSwizzling.m[0m
+[17:31:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCreateCrossConnectionState.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTrailingSidebarTabController.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Convenience.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSimpleXMLExporter.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDragAndDropImageView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCappExporter.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSGraphicsContext+MNAdditions.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPasteboardController.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXResizableScrollView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedCell.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNCoalescing.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCachingImageManager.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeWellButton.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUndoManager.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextEditor.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDXMLElement.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchToggleButton.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCycleNode.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m main.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasViewController.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchColorView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXView.m[0m
+[17:31:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCResizeKnobView.m[0m
+[17:31:58]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMarkdownExportViewController.m[0m
+[17:31:58]: [35m[33m▸[0m [39;1mLinking[0m app[0m
+[17:31:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Printing.apptheme[0m
+[17:31:58]: [35m[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist[0m
+[17:31:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Classic\ Tinted.appclipart[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Teal.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Coffee.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/thawte.cer[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Greyscale.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Pods/Target\ Support\ Files/Pods-app\ for\ macOS/Pods-app\ for\ macOS-acknowledgements.markdown[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/startComCertAuthG2.cer[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Tropical.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Fresh.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m Resources/app.sdef[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Delight.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Elegant.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Candyland.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Vintage.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Blackboard.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Classic.appclipart[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m Resources/Colors[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Tropical\ Tinted.appclipart[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m Resources/Acknowledgements.rtf[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/startssl.cer[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/isrgrootx1.cer[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/geotrust.cer[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Ocean.apptheme[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Tropical.appclipart[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCopying[0m Pods-app\ for\ macOS-metadata.plist[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.xib[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappRegisterWindowController.xib[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.xib[0m
+[17:31:59]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.xib[0m
+[17:32:00]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadCompleteViewController.xib[0m
+[17:32:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.xib[0m
+[17:32:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeCollectionViewItem.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappEditAccountWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXappSingleFileExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyappPreferencesViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareLinkViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintOutlineTableView.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowToolbarController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadDocumentViewController.xib[0m
+[17:32:01]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[17:32:04]: [35m[33m▸[0m [39;1mProcessing[0m appMac-Info.plist[0m
+[17:32:04]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/appQuickLookPlugIn.qlgenerator[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/appSpotlightImporter.mdimporter[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Reachability.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Ashton.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/AppReceiptValidator.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/ZIPFoundation.framework[0m
+[17:32:05]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[17:32:05]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[17:32:05]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Helper.app[0m
+[17:32:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Quick\ Entry.app[0m
+[17:32:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app.app[0m
+[17:32:06]: [35m[33m▸[0m [39;1mAnalyzing[0m app for macOS/app for macOS Tests [Debug][0m
+[17:32:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:06]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:32:06]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[17:32:06]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[17:32:06]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:32:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[17:32:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTextTests.m[0m
+[17:32:31]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNTestHelper.m[0m
+[17:32:31]: [35m[33m▸[0m [39;1mCompiling[0m SSWZipTests.m[0m
+[17:32:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyTests.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextTests.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNTestHelper.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZipTests.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyTests.m[0m
+[17:32:32]: [35m[33m▸[0m [39;1mLinking[0m app\[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/FreeMind.mm[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/ExportNewDocument.applescript[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ touch\ Document\ Version\ 1.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 3.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/TextBundleRoundtrip.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Security\ Scoped\ Bookmark.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/MNCText\ Import.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Layout\ Tests.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/SingleChildSameName.opml[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/SpotlightTestV6.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m WatchModel.plist[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 2.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/SpotlightTestV4.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/TaskPaperExportDocument.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/SpotlightTestV5.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/CSV\ Import.csv[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/MindJet\ Test.mmap[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Style.xmind[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/taskPaperExport.taskpaper[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/WatchExport.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/MindJet\ Exported.mmap[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 5.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/exampleDoc.taskpaper[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/CSV\ Export.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/XMindMap.xmind[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 6.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/iPhone\ Settings.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/LayoutChange.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/RewireNodeTest.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Empty\ Document.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/CrossConnectionPerformance.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Packliste.rtf[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Packliste.txt[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Markdown\ Roundtrip.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 1.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/Markdown\ Exported.md[0m
+[17:32:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Tests/Test\ Documents/app\ Document\ Version\ 4.app[0m
+[17:32:32]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[17:32:32]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[17:32:32]: [35m[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'[0m
+[17:32:33]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app\ for\ macOS\ Tests.xctest[0m
+[17:32:33]: [35m[33m▸[0m [39;1mAnalyze[0m Succeeded[0m
+[17:32:33]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[17:32:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app Helper [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/appQuickLookPlugIn [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/appSpotlightImporter [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app Quick Entry [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:32:34]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app for macOS [Debug][0m
+[17:32:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:34]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:32:34]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:32:35]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:32:36]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[17:32:36]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[17:32:36]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[17:32:36]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Quick\ Entry.app[0m
+[17:32:36]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app.app[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuild[0m Succeeded[0m
+[17:32:37]: ▸ [35m2018-04-03 17:32:37.132 xcodebuild[56075:225299]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[17:32:37]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-EE91BC15-D755-4003-AF9C-FD9EABF4FE14/app for macOS Tests-BB14869B-516E-4485-82AD-1602D0006E94/Session-app for macOS Tests-2018-04-03_173237-kgviqn.log[0m
+[17:32:37]: ▸ [35m2018-04-03 17:32:37.132 xcodebuild[56075:219803] [MT] IDETestOperationsObserverDebug: (CCBF5B21-57C6-45B1-9A8E-A149557ED552) Beginning test session app for macOS Tests-CCBF5B21-57C6-45B1-9A8E-A149557ED552 at 2018-04-03 17:32:37.132 with Xcode 9E145 on target <DVTLocalComputer: 0x7fc0b22e9f30 (My Mac | x86_64)> (10.13.4 (17E199))[0m
+[17:32:37]: ▸ [35m2018-04-03 17:32:37.136 xcodebuild[56075:225299]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[17:32:37]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-EE91BC15-D755-4003-AF9C-FD9EABF4FE14/Purchasing Tests macOS-FE53876D-C049-4CFC-8CA7-5340C577EC62/Session-Purchasing Tests macOS-2018-04-03_173237-gHlkf3.log[0m
+[17:32:37]: ▸ [35m2018-04-03 17:32:37.136 xcodebuild[56075:219803] [MT] IDETestOperationsObserverDebug: (58CCBF04-15AF-4425-A3D3-1068B2D9D60B) Beginning test session Purchasing Tests macOS-58CCBF04-15AF-4425-A3D3-1068B2D9D60B at 2018-04-03 17:32:37.136 with Xcode 9E145 on target <DVTLocalComputer: 0x7fc0b22e9f30 (My Mac | x86_64)> (10.13.4 (17E199))[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug][0m
+[17:32:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[17:32:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug][0m
+[17:32:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug][0m
+[17:32:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:37]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[17:32:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:37]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app Helper [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/appQuickLookPlugIn [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/appSpotlightImporter [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for macOS Tests [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app Quick Entry [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:32:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for macOS [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-app for macOS-app for macOS (Direct) [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mCompiling[0m Pods-app\ for\ macOS-app\ for\ macOS\ (Direct)-dummy.m[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-app\ for\ macOS-app\ for\ macOS\ (Direct).a[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app for macOS (Direct) [Debug][0m
+[17:32:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:32:38]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:32:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:33:05]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/Model Controller/MNCTaskCompletionProgressCalculator.swift:59:70: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:33:05]: ▸ [35mlet childCompletionStates: [CompletionState] = task.children.flatMap { return self.calculateCompletionProgressAndUpdateState(from: $0) }[0m
+[17:33:05]: ▸ [35m[36m                                      ^~~~~~~[0m
+[17:33:05]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Sources/ViewModel/MNCNodeLayoutStrategyLeftRight.swift:119:39: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[17:33:05]: ▸ [35mreturn supernode.subnodes.flatMap {[0m
+[17:33:05]: ▸ [35m[36m                                                                     ^~~~~~~[0m
+[17:33:05]: [35m[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch[0m
+[17:33:10]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+MNPlatformCompatibility.m[0m
+[17:33:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCExporter.m[0m
+[17:33:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m[0m
+[17:33:10]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m[0m
+[17:33:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m[0m
+[17:33:11]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m NSWindow+FullScreen.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Alignment.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontManager.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextView.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNDefaults.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantButtonCell.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersSharingService.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorViewController.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m[0m
+[17:33:12]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNXSearchField.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m NSEvent+MNAdditions.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNCollectionView.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorGridView.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteIndicatorButton.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m NSImage+MNAdditions.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNXappSingleFileExportViewController.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m[0m
+[17:33:13]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedControl.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNXKeyCommand.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m NSGraphicsContext+MNAdditions.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineRowView.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNXSingleAxisScrollView.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m[0m
+[17:33:14]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeWellButton.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArt.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserItem.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCTask.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCappExporter.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextAlignmentValueTransformer.m[0m
+[17:33:15]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXRubberBandView.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXPageSliderCell.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+NodeActions.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXSanitizingTextView.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m MNXThingsAppleScriptExporter.m[0m
+[17:33:16]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateNodeKnobState.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadDocumentViewController.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXOpenBrowserSharingService.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoLaunchWindowController.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m[0m
+[17:33:17]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasView.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNVector.m[0m
+[17:33:18]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m NSPopover+MNDetach.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m NSScrollView+ScrollingAdditions.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedControl.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Animation.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXSheetWindowController.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineDataSource.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSearchCellView.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.m[0m
+[17:33:19]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.m[0m
+[17:33:20]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m[0m
+[17:33:20]: [35m[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Insertion.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m NSView+LayoutConstraintFiltering.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeView.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorSectionViewController.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m NSApplication+LaunchServices.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachedTextField.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXFoldingIndicatorButton.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeInteractionState.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXSwitch.m[0m
+[17:33:21]: [35m[33m▸[0m [39;1mCompiling[0m MNXDraggingOperationState.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappEditAccountWindowController.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXQuickLookController.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m NSPasteboard+Additions.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateCrossConnectionKnobState.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXResizableScrollView.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoOverlayView.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyappDocument.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleController.m[0m
+[17:33:22]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyapp.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachment.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m[0m
+[17:33:23]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeView.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m NSFontDescriptor+Convenience.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextFinderClient.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXScrollView.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m NSCursor+ObjectManipulationCursors.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextController.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCContent.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasInteractionState.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesView.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNViewActions.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m[0m
+[17:33:24]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCFileLink.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNXClipView.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNXLayoutManager.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineBaseCellView.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m NSString+UUID.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextEditor.m[0m
+[17:33:25]: [35m[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m[0m
+[17:33:26]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCycleNode.m[0m
+[17:33:26]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument+Scripting.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNZooming.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCDevice.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXShadowSeparatorContentView.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadCompleteViewController.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarContainerView.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathView.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyappPreferencesViewController.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell+Bindings.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m[0m
+[17:33:27]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarButtonContainerView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXNumberFormatter.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineTableView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasPrintView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareLinkViewController.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineCellView.m[0m
+[17:33:28]: [35m[33m▸[0m [39;1mCompiling[0m MNCNote.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachableButtonCell.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m NSSharingService+MNXAdditions.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m NSString+Paths.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXFunctions.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedCell.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m NSFont+Convenience.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorClipView.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m[0m
+[17:33:29]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareWindowController.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m NSBezierPath+MNCGPathRef.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasViewController.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m NSSegmentedControl+MNAdditions.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappRegisterWindowController.m[0m
+[17:33:30]: [35m[33m▸[0m [39;1mCompiling[0m MNCAsset.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCText.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportViewController.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedCell.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionState.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m[0m
+[17:33:31]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXSidebarContainer.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXCreateCrossConnectionState.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserCell.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXTaskButton.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas.m[0m
+[17:33:32]: [35m[33m▸[0m [39;1mCompiling[0m MNXAppDelegate.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXDragAndDropImageView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCKnobView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorSwatchView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeAccessoryButton.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m[0m
+[17:33:33]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverManager.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNError.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.m[0m
+[17:33:34]: [35m[33m▸[0m [39;1mLinking[0m app[0m
+[17:33:35]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Fresh.apptheme[0m
+[17:33:35]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Coffee.apptheme[0m
+[17:33:35]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Blackboard.apptheme[0m
+[17:33:35]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/thawte.cer[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Delight.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/geotrust.cer[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Classic\ Tinted.appclipart[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Ocean.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/isrgrootx1.cer[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m Resources/app.sdef[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Classic.appclipart[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Elegant.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Teal.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Tropical.appclipart[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/startssl.cer[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m Resources/Colors[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Printing.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Stickers/Tropical\ Tinted.appclipart[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Certificates/startComCertAuthG2.cer[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Candyland.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m Resources/Acknowledgements.rtf[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Greyscale.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Vintage.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/Themes/Tropical.apptheme[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/company/app/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCopying[0m Pods-app\ for\ macOS-app\ for\ macOS\ (Direct)-metadata.plist[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappRegisterWindowController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadCompleteViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoLaunchWindowController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeCollectionViewItem.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareWindowController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappEditAccountWindowController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXappSingleFileExportViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.xib[0m
+[17:33:36]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyappPreferencesViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappShareLinkViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintOutlineTableView.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowToolbarController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MNMyappUploadDocumentViewController.xib[0m
+[17:33:37]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[17:33:40]: [35m[33m▸[0m [39;1mProcessing[0m appMac-Info.plist[0m
+[17:33:40]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/appQuickLookPlugIn.qlgenerator[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/appSpotlightImporter.mdimporter[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Ashton.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/AppReceiptValidator.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m Frameworks/Sparkle.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Reachability.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/ZIPFoundation.framework[0m
+[17:33:41]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[17:33:41]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Helper.app[0m
+[17:33:41]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Quick\ Entry.app[0m
+[17:33:42]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app.app[0m
+[17:33:42]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app for macOS [Debug][0m
+[17:33:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/app\ Quick\ Entry.app[0m
+[17:33:42]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m app.app[0m
+[17:33:42]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo macOS [Debug][0m
+[17:33:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m ViewController.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m Main.storyboard[0m
+[17:33:42]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/app-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework[0m
+[17:33:42]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ macOS.app[0m
+[17:33:42]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests macOS [Debug][0m
+[17:33:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:33:42]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumberTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptAssets.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m MockPurchasingServiceConfiguration.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m XCTestCase+ObservableAssertions.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdaterTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m TestAssetLoading.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m LicenseAssets.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m License+Convenience.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidatorTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifierTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m CurrentReceiptValidationTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysisTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m MockDefaults.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m Date+Convenience.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+Convenience.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m DataStoreTestContext.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTestContext.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStoreTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTests.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m MockStorePromotionControllerWrapper.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+DemoData.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCompiling[0m MockStoreKitWrapper.swift[0m
+[17:33:42]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/wildcard.alamofire.org.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_mac_legacy_original_2.2.3.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-root-ca.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity01[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/expired.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-dns-name.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_current_original_trial_and_full.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity02[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_current_original_trial.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/missing-dns-name-and-uri.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_legacy_original_3394.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01.txt[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithoutTrial_SignedWithProduction.json[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity02_rsaCert.der[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_mac_current_trial_and_fullversion.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-uri.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_michaelsandbox_receipt1.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_legacy_original_147.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicenseWithTrial_With_Identity01.json[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity02[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicense_With_Identity01.json[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity01[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/appLicensingProduction_rsaCert.der[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca2.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_current_vpp.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_current_original_fullversionfree.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_mac_legacy_original_2.5.7.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca1.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02.txt[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/test.alamofire.org.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_ios_legacy_vpp.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/multiple-dns-names.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca1.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/app_mac_current_trial.b64[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithTrial_SignedWithProduction.json[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca2.cer[0m
+[17:33:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity01_rsaCert.der[0m
+[17:33:42]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Tests\ macOS.xctest[0m
+[17:33:42]: [35m[33m▸[0m [39;1mBuilding[0m app for macOS/app for macOS Tests [Debug][0m
+[17:33:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[17:33:42]: [35m[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'[0m
+[17:33:43]: ▸ [35m[39;1mAll tests[0m
+[17:33:43]: ▸ [35mTest Suite [39;1mapp for macOS Tests.xctest[0m started[0m
+[17:33:43]: ▸ [35m[39;1mMNCCSVExporterTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCounterOfLevels ([31m0.359[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCSV (0.024 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCSVisNotEmpty (0.024 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testHeader (0.023 seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCCSVImporterTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testImport (0.022 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testMainNodes (0.019 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testStructure (0.019 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testTotalNodes (0.019 seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCCanvasControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCanvasControllerSetup (0.023 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testInsertParentNode ([33m0.055[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRemoveAllNodes ([33m0.026[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRemoveNode (0.025 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRemoveNodeAndSubnodes ([33m0.026[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRepresentedObject ([33m0.032[0m seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCCanvasSelectionControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCanvasSelectionConvenienceGetters (0.004 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCanvasSelectionEqualsSelectionController (0.003 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testCanvasSelectionGetsResetAfterSelectionChange (0.003 seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCCanvasTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testAddNode (0.001 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRemoveAllNodes (0.001 seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCCollisionControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testBoundsCollision ([33m0.065[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testMindMapControllerSelectionMovement ([33m0.093[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testRectHitTest ([33m0.043[0m seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCDocument4to5MigrationControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testMigration (0.017 seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testTextMigration (0.021 seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCDocument5to6MigrationControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testMigration ([33m0.028[0m seconds)[0m
+[17:33:44]: ▸ [35m[39;1mMNCDocumentKVOControllerTests[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testNearestMindMapObject ([33m0.042[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault ([33m0.033[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft ([33m0.032[0m seconds)[0m
+[17:33:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleDefault ([33m0.031[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleLeft ([33m0.030[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleManual ([33m0.030[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleRight ([33m0.031[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault ([33m0.032[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight ([33m0.032[0m seconds)[0m
+[17:33:45]: ▸ [35m[32;1m✓[0m testSortingTaskStateRightAligned (0.023 seconds)[0m
+[17:33:45]: ▸ [35m[39;1mMNCDocumentOpenPerformanceTests[0m
+[17:33:56]: ▸ [35m[33m◷[0m testLargeMindMapWithTasks measured ([31m1.140[0m seconds)[0m
+[17:33:56]: ▸ [35m[32;1m✓[0m testLargeMindMapWithTasks ([31m11.771[0m seconds)[0m
+[17:34:14]: ▸ [35m[33m◷[0m testMindMapWithLotsOfCrossConnections measured ([31m1.735[0m seconds)[0m
+[17:34:14]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfCrossConnections ([31m17.805[0m seconds)[0m
+[17:34:49]: ▸ [35m[33m◷[0m testMindMapWithLotsOfNodes measured ([31m3.391[0m seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfNodes ([31m34.515[0m seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCDocumentTests[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithUnsupportedVersionNumbers (0.013 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion1 (0.025 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion2 (0.024 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion3 (0.023 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion4 (0.025 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion5 ([33m0.026[0m seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion6 ([33m0.026[0m seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpeningEmptyDocument (0.012 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenappTouchDocument (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testResolvingSecurityScopedBookmark ([33m0.031[0m seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCDocumentVersionDecisionTests[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testExport (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testNewDocument (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testOpenDocument (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCFontExtractorTests[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testCompoundEmoji (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testEmoji (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testEmptyString (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testFontStyle (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testFullyEmojiString (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testFullySymbolic (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testFullySymbolicAndEmojiString (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testNormalFont (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testSymbol (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testSymbolAndEmoji (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testSymbolWithWrongFont (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCFontManagerTests[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion1 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion10 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion100 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion11 (0.008 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion12 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion13 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion14 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion15 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion16 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion17 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion18 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion19 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion2 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion20 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion21 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion22 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion23 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion24 (0.003 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion25 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion26 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion27 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion28 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion29 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion3 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion30 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion31 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion32 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion33 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion34 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion35 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion36 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion37 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion38 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion39 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion4 (0.012 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion40 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion41 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion42 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion43 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion44 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion45 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion46 (0.010 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion47 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion48 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion49 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion5 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion50 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion51 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion52 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion53 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion54 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion55 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion56 (0.003 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion57 (0.014 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion58 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion59 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion6 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion60 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion61 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion62 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion63 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion64 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion65 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion66 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion67 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion68 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion69 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion7 (0.006 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion70 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion71 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion72 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion73 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion74 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion75 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion76 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion77 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion78 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion79 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion8 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion80 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion81 (0.013 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion82 (0.003 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion83 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion84 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion85 (0.003 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion86 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion87 (0.005 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion88 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion89 (0.003 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion9 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion90 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion91 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion92 (0.004 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion93 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion94 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion95 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion96 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion97 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion98 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion99 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily1 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily2 (0.002 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily3 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily4 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily5 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily6 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily1 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily10 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily11 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily12 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily13 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily14 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily2 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily3 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily4 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily5 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily6 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily7 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily8 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily9 (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCFontStyleTests[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testAttributedStringInit (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testNilInit (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testNodeRewire ([33m0.050[0m seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testNormalInit (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[32;1m✓[0m testSymbolCharacter (0.001 seconds)[0m
+[17:34:49]: ▸ [35m[39;1mMNCFreeMindImporterTests[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testBranchWidth ([31m2.048[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testBubbleShape ([33m0.092[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testCustomTitleColor ([33m0.088[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testImport ([33m0.088[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testLinks ([33m0.090[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testMainNodeHasPillShape ([33m0.090[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testNodeAlignment ([33m0.093[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testNodeAttributedTitle ([33m0.089[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testNodeTitle ([33m0.089[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.089[0m seconds)[0m
+[17:34:52]: ▸ [35m[32;1m✓[0m testParsesBranchColor ([33m0.089[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testShapeFillColor ([33m0.090[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testSpecialCharactersDecoding (0.016 seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreConnectingCorrectNodes ([33m0.089[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreImported ([33m0.089[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsHaveCorrectColor ([33m0.089[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatFoldingIsRespected ([33m0.089[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatFontNamesAreParsed ([33m0.090[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatFontSizesAreParsed ([33m0.090[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatNodesDeriveBubbleStyleFromParent ([33m0.090[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleCanOverrideFillColor ([33m0.090[0m seconds)[0m
+[17:34:53]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleDoesntHaveDerivedFillColor ([33m0.093[0m seconds)[0m
+[17:34:54]: ▸ [35m[32;1m✓[0m testThatNotesAreImported ([31m0.177[0m seconds)[0m
+[17:34:54]: ▸ [35m[32;1m✓[0m testThatParsesForkStyle ([33m0.090[0m seconds)[0m
+[17:34:54]: ▸ [35m[39;1mMNCFunctionsTests[0m
+[17:34:54]: ▸ [35m[32;1m✓[0m testCGFloatEquality (0.001 seconds)[0m
+[17:34:54]: ▸ [35m[32;1m✓[0m testStringByRemovingCharactersInSet (0.001 seconds)[0m
+[17:34:54]: ▸ [35m[39;1mMNCHelloPayloadBuilderTests[0m
+[17:34:54]: ▸ [35m[32;1m✓[0m testPayloadConstruction (0.002 seconds)[0m
+[17:34:54]: ▸ [35m[39;1mMNCImageExporterTests[0m
+[17:34:57]: ▸ [35m[32;1m✓[0m testImageRepresentation ([31m2.895[0m seconds)[0m
+[17:35:00]: ▸ [35m[32;1m✓[0m testImageRepresentationWithoutBackground ([31m3.382[0m seconds)[0m
+[17:35:03]: ▸ [35m[32;1m✓[0m testImageRepresentationWithPadding ([31m2.676[0m seconds)[0m
+[17:35:13]: ▸ [35m[32;1m✓[0m testImageRepresentationWithScaling ([31m10.307[0m seconds)[0m
+[17:35:13]: ▸ [35m[39;1mMNCInsertPositionCalculatorTests[0m
+[17:35:13]: ▸ [35m[32;1m✓[0m testInsertionOfSiblingsAboveAndBelow (0.003 seconds)[0m
+[17:35:13]: ▸ [35m[32;1m✓[0m testInsertPositionForManualLeftRightLayout (0.003 seconds)[0m
+[17:35:13]: ▸ [35m[32;1m✓[0m testInsertPositionForTopDownLayout (0.003 seconds)[0m
+[17:35:13]: ▸ [35m[39;1mMNCLayoutCalculatorTests[0m
+[17:35:13]: ▸ [35m[32;1m✓[0m testHorizontalLayout (0.005 seconds)[0m
+[17:35:14]: ▸ [35m[33m◷[0m testHorizontalLayoutCalculationPerformance measured (0.022 seconds)[0m
+[17:35:14]: ▸ [35m[32;1m✓[0m testHorizontalLayoutCalculationPerformance ([31m1.588[0m seconds)[0m
+[17:35:15]: ▸ [35m[32;1m✓[0m testLayoutForLargeSupernodes (0.003 seconds)[0m
+[17:35:15]: ▸ [35m[32;1m✓[0m testVerticalLayout (0.005 seconds)[0m
+[17:35:16]: ▸ [35m[33m◷[0m testVerticalLayoutCalculationPerformance measured (0.022 seconds)[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testVerticalLayoutCalculationPerformance ([31m1.591[0m seconds)[0m
+[17:35:16]: ▸ [35m[39;1mMNCLayoutControllerTests[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testDefaultLayoutControllerDeterminism (0.023 seconds)[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testLayoutStyleChange0 ([33m0.086[0m seconds)[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testLayoutStyleChange1 ([33m0.087[0m seconds)[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testLayoutStyleChange2 ([33m0.088[0m seconds)[0m
+[17:35:16]: ▸ [35m[32;1m✓[0m testLayoutStyleChange3 ([33m0.089[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testLayoutStyleChange4 ([33m0.089[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testLayoutStyleChange5 ([31m0.113[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testThatLeftRightComputesTheSameAsReference ([31m0.101[0m seconds)[0m
+[17:35:17]: ▸ [35m[39;1mMNCMarkdownImporterTests[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testContent ([33m0.046[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([33m0.051[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.044[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testStructure ([33m0.046[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testTodos ([33m0.046[0m seconds)[0m
+[17:35:17]: ▸ [35m[39;1mMNCMindJetImporterTests[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.111[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testExportedBackgroundColor ([31m0.146[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testExportedNodeTextFormatting ([31m0.142[0m seconds)[0m
+[17:35:17]: ▸ [35m[32;1m✓[0m testHyperlinks ([33m0.082[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testImages ([31m0.349[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testImport ([33m0.080[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNodeAlignment ([33m0.080[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNodeFormatting ([33m0.081[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNodeText ([33m0.081[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([33m0.082[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNotes ([33m0.084[0m seconds)[0m
+[17:35:18]: ▸ [35m[32;1m✓[0m testNotesAndHyperlinkOnSameNode ([33m0.081[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.081[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTaskStatus ([31m0.142[0m seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCMindMapTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testImportWithInvalidLayoutStyle (0.002 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCMyappTokenStoreTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testMyappKeyRetrieval (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTokenStoring (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCNodeControllerTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testParsingOfNodeDataFromTitle (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCNodeLayoutCalculatorTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testNodeLayoutCalculation (0.002 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCNodeStyleCalculatorTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testNodeStyleDerivationForLevelOneNodes (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testNodeStyleDerivationForLevelTwoNodesAndBelow (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testStyleDerivationForMainNodes (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCNodeStyleTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testGCDCalculation (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCOPMLImporterTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.036[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testSpecialSingleChildCase (0.016 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testStructure ([33m0.035[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTasks ([33m0.038[0m seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCPasteboardTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testCanvasObjectPasteboardParserRoundTrip ([31m0.151[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testEmptyPasteboard (0.013 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardCanvasObject (0.005 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardController ([31m0.152[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardCrossConnectionStyle (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardEmptyString (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardFontStyle (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardImage ([33m0.084[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardNodeStyle (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testPasteboardString (0.007 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCPropertyRepresentationTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV6PropertyRepresentation ([33m0.039[0m seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCSetSynchronizerTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testInitialSyncMerging (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurAddition (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurAdditionTheirAddition (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurAdditionTheirRemoval (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurRemoval (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurRemovalTheirAddition (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testOurRemovalTheirRemoval (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testSyncFailureRollback (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testThatInvalidStateExceptionIsThrown (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTheirAddition (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTheirRemoval (0.001 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCSpotlightImporterTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testSpotlightIndexerForUnsupportedDocumentVersion (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV4SpotlightIndexerForValidDocument (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForBigDocument ([33m0.069[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForEmptyDocument (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForValidDocument (0.005 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithCrossConnectionTitle (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithNotes (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testV6SpotlightIndexer (0.003 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCStyleDocument1to2MigrationTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testThatStyleDocumentUpgradeAndDowngradeResultsInOriginalStyleDocument (0.006 seconds)[0m
+[17:35:19]: ▸ [35m[39;1mMNCStyleProxyTests[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testBoxing (0.018 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testKeyPathAccess (0.013 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testStyleProxyObjectUpdate (0.015 seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTextManipulation ([33m0.040[0m seconds)[0m
+[17:35:19]: ▸ [35m[32;1m✓[0m testTextSpecialCase (0.020 seconds)[0m
+[17:35:20]: ▸ [35m[32;1m✓[0m testThatRemovingLastObjectResultsInEmptyStyleProxy (0.012 seconds)[0m
+[17:35:20]: ▸ [35m[32;1m✓[0m testThatRemovingOfValuesResultsInCorrectStyleValue (0.014 seconds)[0m
+[17:35:20]: ▸ [35m[32;1m✓[0m testValueTransformer (0.015 seconds)[0m
+[17:35:20]: ▸ [35m[39;1mMNCTaskControllerTest[0m
+[17:35:27]: ▸ [35m[33m◷[0m testActivatingDeactivatingTaskStatePerformance measured ([31m0.593[0m seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testActivatingDeactivatingTaskStatePerformance ([31m7.426[0m seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testMultipleTaskSettingOnDeepTree (0.003 seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testProgressCalculationOnDeepTree (0.004 seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testProgressCalculationOnFlatTree (0.002 seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnDeepTree (0.003 seconds)[0m
+[17:35:27]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnFlatTree (0.002 seconds)[0m
+[17:35:29]: ▸ [35m[33m◷[0m testRefreshPerformance measured ([33m0.026[0m seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testRefreshPerformance ([31m1.667[0m seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testShowTaskControlOnFlatTree (0.002 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTaskCreationViaTitle (0.004 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTaskPropagationOnDeepTree (0.002 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTaskPropagationOnFlatTree (0.002 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTogglingNodeStatesOnFlatTree (0.002 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTogglingOfCompletionStateOnDeepTree (0.003 seconds)[0m
+[17:35:29]: ▸ [35m[32;1m✓[0m testTogglingOfTaskStatesOnDeepTree (0.003 seconds)[0m
+[17:35:33]: ▸ [35m[33m◷[0m testTogglingTaskStatePerformance measured ([31m0.256[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testTogglingTaskStatePerformance ([31m4.010[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testUndoTaskToggleOnDeepTree (0.004 seconds)[0m
+[17:35:33]: ▸ [35m[39;1mMNCTaskPaperExporterTests[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testTaskPaperExport ([33m0.043[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testTaskPaperExportWithOmniFocusConfiguration ([33m0.038[0m seconds)[0m
+[17:35:33]: ▸ [35m[39;1mMNCTaskPaperImporterTests[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testInlineTags ([33m0.035[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testNotes ([33m0.034[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.035[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testStructure ([33m0.035[0m seconds)[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testTasks ([33m0.035[0m seconds)[0m
+[17:35:33]: ▸ [35m[39;1mMNCTextBundleExporterTests[0m
+[17:35:33]: ▸ [35m[32;1m✓[0m testBundleContent ([33m0.071[0m seconds)[0m
+[17:35:33]: ▸ [35m[39;1mMNCTextBundleImporterTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([31m0.528[0m seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testImportOfTextBundleFile ([31m0.138[0m seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCTextExporterTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testNodeOrderOfPlainTextExport ([33m0.094[0m seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCTextOutlineImporterTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testPasteboard ([31m0.200[0m seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testPlainTextImport ([31m0.102[0m seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testRichTextImport ([31m0.103[0m seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCTheme2to3MigrationTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithColor (0.006 seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithNode (0.007 seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testThatThemeUpgradeAndDowngradeResultsInOriginalTheme (0.009 seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCThemeDataSourceTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testThemeOrder (0.001 seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCThemeManagerTests[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testAddTheme (0.011 seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testRemoveTheme (0.010 seconds)[0m
+[17:35:34]: ▸ [35m[32;1m✓[0m testStandardThemes (0.001 seconds)[0m
+[17:35:34]: ▸ [35m[39;1mMNCThemeTests[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testThemePreviewImageGeneration ([31m0.378[0m seconds)[0m
+[17:35:35]: ▸ [35m[39;1mMNCThingsExporterTests[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testExportURLGenertion ([33m0.064[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testJSONDataExport ([33m0.059[0m seconds)[0m
+[17:35:35]: ▸ [35m[39;1mMNCXMindImporterTests[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testBackgroundColor ([33m0.093[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testContent ([33m0.048[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testCrossConnections ([33m0.050[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testLinks ([33m0.053[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.050[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testStructure ([33m0.053[0m seconds)[0m
+[17:35:35]: ▸ [35m[39;1mMNCXMindStyleImporterTest[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testBorder ([31m0.201[0m seconds)[0m
+[17:35:35]: ▸ [35m[32;1m✓[0m testBorderLineWidth ([31m0.161[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testColor ([31m0.168[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCrossConnectionStyle ([31m0.159[0m seconds)[0m
+[17:35:36]: ▸ [35m[39;1mMNCZoomingCalculatorTests[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCalculatorZoomIn (0.001 seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCalculatorZoomOut (0.001 seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCalculatorZoomScaleEqual (0.001 seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testDifferentInsets (0.001 seconds)[0m
+[17:35:36]: ▸ [35m[39;1mMNCiThoughtsImporterTests[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testBoundariesV4 ([33m0.077[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.186[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCrossConnectionsV3 ([33m0.058[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testCrossConnectionsV4 ([33m0.075[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testHyperlinks ([31m0.181[0m seconds)[0m
+[17:35:36]: ▸ [35m[32;1m✓[0m testHyperlinksV3 ([33m0.057[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testHyperlinksV4 ([33m0.073[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testImages ([31m0.433[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testImport ([31m0.186[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testImportV3 ([33m0.056[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testImportV4 ([33m0.073[0m seconds)[0m
+[17:35:37]: ▸ [35m[32;1m✓[0m testLayoutStyle ([31m0.180[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testLayoutStyleV3 ([31m0.177[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testLineTypeV4 ([33m0.074[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeAlignment ([31m0.181[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeAlignmentV3 ([33m0.057[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeAlignmentV4 ([33m0.075[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeFormatting ([31m0.181[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeFormattingV3 ([33m0.057[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeFormattingV4 ([33m0.073[0m seconds)[0m
+[17:35:38]: ▸ [35m[32;1m✓[0m testNodeText ([31m0.187[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([31m0.179[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNodeTextV3 ([33m0.058[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNodeTextV4 ([33m0.075[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNotes ([31m0.181[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.180[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNumberOfNodesV3 ([33m0.057[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testNumberOfNodesV4 ([33m0.074[0m seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testTasks ([31m0.181[0m seconds)[0m
+[17:35:39]: ▸ [35m[39;1mMNColorTests[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testBlackWhiteComplementColor (0.001 seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testColorComponentRetrieval (0.001 seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testDarkenedColor (0.001 seconds)[0m
+[17:35:39]: ▸ [35m[32;1m✓[0m testDerivedColor (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testLightenedColor (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testPropertyRepInit (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testRGBComplementColor (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testWebColorString3Init (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testWebColorString6Init (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testWebColorString8Init (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[39;1mMNTextTests[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testApplyStyle ([33m0.028[0m seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testApplyStyleInRange (0.004 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testEditing (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testEmptyInit (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testFindString (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testInit (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testSavingAndLoadingOfStringWithSpecialControlCharacters (0.002 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testSetString (0.002 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testTextWithAttributes (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testTextWithFont ([33m0.073[0m seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testTextWithFontMonospaced ([33m0.057[0m seconds)[0m
+[17:35:40]: ▸ [35m[39;1mMNXBetaControllerTests[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testBetaInformationEncryption (0.002 seconds)[0m
+[17:35:40]: ▸ [35m[39;1mMNXOpenURLRouteTests[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testBetaActivationRoute (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[32;1m✓[0m testPurchaseRoute (0.001 seconds)[0m
+[17:35:40]: ▸ [35m[39;1mMNXScriptingTests[0m
+[17:35:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsCSV ([31m1.025[0m seconds)[0m
+[17:35:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsDocX ([31m0.244[0m seconds)[0m
+[17:35:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsFreeMind ([31m0.406[0m seconds)[0m
+[17:35:42]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsMarkdown ([31m0.489[0m seconds)[0m
+[17:35:42]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsMSFF ([31m0.483[0m seconds)[0m
+[17:35:43]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsOPML ([31m0.414[0m seconds)[0m
+[17:35:43]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsPDF ([31m0.427[0m seconds)[0m
+[17:35:44]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsPNG ([31m0.398[0m seconds)[0m
+[17:35:44]: ▸ [35m[39;1mMorphingTests[0m
+[17:35:44]: ▸ [35m[32;1m✓[0m testNormalization (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[33m◷[0m testPerformance measured ([31m0.198[0m seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testPerformance ([31m2.569[0m seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testSimpleInsert (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testSimpleMatch (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testSimpleMorph (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[39;1mNSAttributedStringMarkdownTests[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testBoldItalic (0.002 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testBoldMarkdownConversion (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testCombiningAttributes (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testItalicMarkdownConversion (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testLinkConversion (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testParagraphs (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testPlainTextConversion (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testStrikethroughConversion (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[39;1mNSRangeSwiftTests[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testFullRange (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testSubStringFromIndex (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testSubStringFromRange (0.001 seconds)[0m
+[17:35:46]: ▸ [35m[39;1mSSWZipTests[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testAddCompressedEntry (0.021 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testAddSymbolicLink (0.009 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testAddUncompressedEntry (0.017 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testCreateCompressedArchive (0.007 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testCreateNestedDirectoryStrucutre (0.009 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testCreateUncompressedArchive (0.008 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testDetectionOfUnspportedFormatFeatures ([33m0.027[0m seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testLastModFileDate (0.009 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testLastModFileTime (0.008 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testNonUnixOSTypes (0.006 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testPosixPermissions (0.008 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testRemoveCompressedEntry (0.019 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testRemoveUncompressedEntry (0.017 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToData (0.019 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToURL (0.017 seconds)[0m
+[17:35:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderArchive (0.006 seconds)[0m
+[17:35:47]: ▸ [35m[33m◷[0m testUnzipCompressedFolderEntries measured (0.003 seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderEntries ([31m0.291[0m seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipItemAtURL ([33m0.036[0m seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipItemAtURLErrorConditions (0.006 seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToData (0.013 seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToURL (0.014 seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderArchive (0.005 seconds)[0m
+[17:35:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderEntries (0.014 seconds)[0m
+[17:35:48]: ▸ [35m[33m◷[0m testZipDirectoryContentsAtURL measured ([33m0.094[0m seconds)[0m
+[17:35:48]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURL ([31m1.201[0m seconds)[0m
+[17:35:48]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURLErrorConditions (0.006 seconds)[0m
+[17:35:48]: ▸ [35m[32;1m	 Executed 461 tests, with 0 failures (0 unexpected) in 124.357 (124.619) seconds[0m
+[17:35:48]: ▸ [35m[0m
+[17:35:49]: ▸ [35m[39;1mSelected tests[0m
+[17:35:49]: ▸ [35mTest Suite [39;1mPurchasing Tests macOS.xctest[0m started[0m
+[17:35:49]: ▸ [35m[39;1mCurrentReceiptParsingTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testiOSReceiptValidation ([31m0.315[0m seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testMacOSReceiptValidation (0.007 seconds)[0m
+[17:35:49]: ▸ [35m[39;1mLicenseValidatorTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testBrokenLicenseData (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testBrokenSignedLicenseData (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testEmtpyData (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testMissingData (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testParsingSignedLicense1 (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSignedLicense (0.010 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSignedLicenseWithTrial (0.003 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicense (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicenseWithTrial (0.003 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSkippingCertificate (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testValidatingSkippingDeviceIdentifier (0.003 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testWrongCertificate (0.006 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifier (0.008 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifierAndCertificate (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[39;1mPromotedVisibilityUpdaterTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testCatalogNeeded (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testDoubleUpdateProtection (0.006 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testInitialVisibilityUpdates (0.000 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testOverriddenUpdating (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testVisibiliesForFullVersion (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testVisibiliesFromTrial (0.003 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testVisibilitiesForPendingDecision (0.003 seconds)[0m
+[17:35:49]: ▸ [35m[39;1mPurchaseServiceDataStoreTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testPersistence (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testUpdateMethods (0.002 seconds)[0m
+[17:35:49]: ▸ [35m[39;1mPurchaseServiceTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testActiveTrialLicenseTrumpsViewerOnly (0.011 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testAdditionalAvailableDiscountedProductOverrulesReceipt (0.006 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testFromExpiredIAPTrialToViewerOnly (0.008 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testFromIAPTrialToViewerOnly (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testFullPurchase (0.006 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testFullPurchaseFromTrialLicense (0.007 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testIAPTrialExpiry (0.019 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testIAPTrialVsLongerTrialLicense (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testIAPTrialVsShorterTrialLicense (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testLicenseTrialExpiry (0.023 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithExistingLicense (0.008 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithoutExistingLicense (0.006 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInvalidReceiptData (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testReceiptOverrulesAdditionalAvailableDiscountedProduct (0.005 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testStartingTrial (0.008 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testViewerOnlyThenTrialLicenseThenViewerOnly (0.009 seconds)[0m
+[17:35:49]: ▸ [35m[39;1mSignatureVerifierTests[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testCorrectSignatures (0.004 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testMalformedData (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testMalformedSignatureData (0.001 seconds)[0m
+[17:35:49]: ▸ [35m[32;1m✓[0m testMlformedCertificateData (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[33m◷[0m testPerformanceOfSignatureVerification measured (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testPerformanceOfSignatureVerification ([31m0.315[0m seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testWrongSignatures (0.008 seconds)[0m
+[17:35:50]: ▸ [35m[39;1mUpgradePathAnalysisTests[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testConcreteiOSUpgradePathAnalysis (0.008 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testConcreteMacOSUpgradePathAnalysis (0.002 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testiOSLegacyReceiptParsing (0.007 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testMacOSLegacyReceiptParsing (0.005 seconds)[0m
+[17:35:50]: ▸ [35m[39;1mVersionNumberTests[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testDigitsAndDotsComparison (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testDigitsAndDotsParsing (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testDigitsOnly (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m✓[0m testDigitsOnlyParsing (0.001 seconds)[0m
+[17:35:50]: ▸ [35m[32;1m	 Executed 55 tests, with 0 failures (0 unexpected) in 0.883 (0.915) seconds[0m
+[17:35:50]: ▸ [35m[0m
+[17:35:50]: [35m[33m▸[0m [39;1mTest[0m Succeeded[0m
++--------------------+-----+
+|       Test Results       |
++--------------------+-----+
+| Number of tests    | 516 |
+| Number of failures | [32m0[0m   |
++--------------------+-----+
+
+
++------+----------------------------+-------------+
+|                [32mfastlane summary[0m                 |
++------+----------------------------+-------------+
+| Step | Action                     | Time (in s) |
++------+----------------------------+-------------+
+| 1    | Verifying fastlane version | 0           |
+| 2    | clear_derived_data         | 1           |
+| 3    | scan                       | 407         |
++------+----------------------------+-------------+
+
+[17:35:50]: [32mfastlane.tools just saved you 7 minutes! 🎉[0m
+
+#######################################################################
+# fastlane 2.89.0 is available. You are on 2.79.0.
+# You should use the latest version.
+# Please update using `bundle update fastlane`.
+#######################################################################
+
+[32m2.89.0 Improvements[0m
+* [action] Make sure get_version_number targets respond to test_target_type? (#12212) via Josh Holtz
+* [action] Make enable_automatic_code_signing for all configurations (#12187) via Nicolas Braun
+* [produce]Use correct spelling of icloud service in product/service.rb (#12134) via Jakub Knejzlík
+* [action] Add Support for Registering Mac Devices on Apple Developer Portal (#11978) via Baumchen
+* [spaceship] Spaceship delete testflight groups (#12111) via Kenneth Wong
+* [produce] Enable set 'NFC Tag Reading' at 'fastlane produce' cli. (#12179) (#12201) via Kazuhide Takahashi
+* [frameit] frameit documentation describes all parameters from the Framefile (#11662) via funnel20
+* [supply] Clarify difference between SUPPLY_JSON_KEY and SUPPLY_JSON_KEY_DATA via Aaron Brager
+* [action] added custom api_url option to testfairy (#12153) via Josh Holtz
+
+[32m2.88.0 Improvements[0m
+* [action] Fix crashlytics to not autoload gsp_path if api_token is set (#12176) via Josh Holtz
+* Improve error message when specified scheme is not found (#12182) via Cédric Luthi
+* [action] Support checking remote git tags existence (#11675) via Takeru Chuganji
+* Use Android environment to find adb (don't just rely on it being in PATH) (#12168) via Adam Cohen-Rose
+* [snapshot] Make sure matched window has a non-empty frame (#12174) via François Pradel
+* [swift] Fixes string return value and shows all lanes (even without description) (#12171) via Josh Holtz
+* [scan] Default skip_build to true in Scanfile template (#12162) via Aaron Brager
+
+[32m2.87.0 Lots of action fixes and xcodeproj gem update[0m
+* [supply] Added internal track (#12128) via Josh Holtz
+* [Action] get_latest_version handles $(SRCROOT) and tries to get target that isn't test (#12138) via Josh Holtz
+* [Action] app_store_build_number converts return to int if possible (#12148) via Josh Holtz
+* Workspace contained schemes now get loaded (#12147) via Lou Franco
+* Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting iOS projects (#12142) via Hiroyuki Morita
+* [Action] Add use_bundle_exec option to pod_push action (#11947) via Nicolas Braun
+* [match] Write Match encrypted files in binary mode to avoid UndefinedConversion error (#12112) via Michael Smith
+* [Action] Fix a bug that upload_symbols_to_crashlytics fails if path has a space (#12098) via Takeru Chuganji
+
+[32mTo see all new releases, open https://github.com/fastlane/fastlane/releases[0m
+
+[32mPlease update using `bundle update fastlane`[0m
+17:35:53 [[0;32mMESSAGE[0;0m] Platform.swift [Line: 23]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+17:35:53 [[0;32mMESSAGE[0;0m] AshtonHTMLWriter.swift [Line: 173]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:35:53 [[0;32mMESSAGE[0;0m] Data+Serialization.swift [Line: 60]  'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'
+17:35:53 [[0;32mMESSAGE[0;0m] MNCNodeLayoutStrategyLeftRight.swift [Line: 119]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:35:53 [[0;32mMESSAGE[0;0m] Reachability.swift [Line: 136]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+17:35:53 [[0;32mMESSAGE[0;0m] MNCTaskCompletionProgressCalculator.swift [Line: 59]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+17:35:53 [[0;33mWARNING[0;0m] Fastlane exit code: 0
+17:35:53 [[0;32mMESSAGE[0;0m] --------------------- Summary ---------------------
+17:35:53 [[0;32mMESSAGE[0;0m] Ignored Keywords: todo, -Wpragma, type-check (limit:
+17:35:53 [[0;31m ERROR [0;0m] 6. Static Analyzer Warnings
+17:35:53 [[0;31m ERROR [0;0m] Static Analyzer failed

--- a/CallistoTest/mac_build_8745.log
+++ b/CallistoTest/mac_build_8745.log
@@ -1,0 +1,4487 @@
+~~~ Preparing build folder
+[90m$[0m mkdir -p "/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode"
+[90m$[0m cd "/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode"
+[90m$[0m ssh-keyscan "github.com" >> "/Users/administrator/.ssh/known_hosts"
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+# github.com:22 SSH-2.0-libssh_0.7.0
+[90m$[0m git remote set-url origin "git@github.com:IdeasOnCanvas/MindNode.git"
+[90m$[0m git clean "-fdq"
+[90m$[0m git submodule foreach --recursive git clean "-fdq"
+[90m$[0m git fetch -v origin "12f13205ba19175ab7c738ff8d00b8911127365a" || git fetch -v origin "+refs/heads/*:refs/remotes/origin/*" "+refs/tags/*:refs/tags/*"
+From github.com:IdeasOnCanvas/MindNode
+ * branch                  12f13205ba19175ab7c738ff8d00b8911127365a -> FETCH_HEAD
+[90m$[0m git checkout -f "12f13205ba19175ab7c738ff8d00b8911127365a"
+HEAD is now at 12f13205ba... trigger analyser
+[90m$[0m git submodule sync --recursive
+[90m$[0m git submodule update --init --recursive
+[90m$[0m git submodule foreach --recursive git reset --hard
+~~~ Running command
+[90m$[0m #!/bin/bash
+
+if [ "$(ls .scripts/buildkite | grep mac_tests.sh)" ]
+then ./.scripts/buildkite/mac_tests.sh
+else
+echo "----------------------------------"
+echo "##  BuildkiteScript not found   ##"
+echo "##    fallback to old style     ##"
+echo "----------------------------------"
+bundle install --path ~/gems
+bundle exec fastlane mac test
+fi
+Using rake 12.3.0
+Using CFPropertyList 2.3.6
+Using concurrent-ruby 1.0.5
+Using i18n 0.9.3
+Using minitest 5.11.2
+Using thread_safe 0.3.6
+Using tzinfo 1.2.4
+Using activesupport 4.2.10
+Using public_suffix 2.0.5
+Using addressable 2.5.2
+Using babosa 1.0.2
+Using bundler 1.16.0
+Using claide 1.0.2
+Using colored2 3.1.2
+Using cork 0.3.0
+Using nap 1.1.0
+Using open4 1.3.4
+Using claide-plugins 0.9.2
+Using fuzzy_match 2.0.4
+Using cocoapods-core 1.3.1
+Using cocoapods-deintegrate 1.0.2
+Using cocoapods-downloader 1.1.3
+Using cocoapods-plugins 1.0.0
+Using cocoapods-search 1.0.0
+Using cocoapods-stats 1.0.0
+Using netrc 0.11.0
+Using cocoapods-trunk 1.3.0
+Using cocoapods-try 1.1.0
+Using escape 0.0.4
+Using fourflusher 2.0.1
+Using gh_inspector 1.0.3
+Using molinillo 0.5.7
+Using ruby-macho 1.1.0
+Using nanaimo 0.2.3
+Using xcodeproj 1.5.4
+Using cocoapods 1.3.1
+Using redcarpet 3.4.0
+Using cocoapods-acknowledgements 1.1.2
+Using colored 1.2
+Using highline 1.7.10
+Using commander-fastlane 4.4.5
+Using multipart-post 2.0.0
+Using faraday 0.14.0
+Using faraday-http-cache 1.3.1
+Using git 1.3.0
+Using kramdown 1.16.2
+Using no_proxy_fix 0.1.2
+Using sawyer 0.8.1
+Using octokit 4.8.0
+Using unicode-display_width 1.3.0
+Using terminal-table 1.8.0
+Using danger 5.5.7
+Using thor 0.20.0
+Using danger-swiftlint 0.12.1
+Using declarative 0.0.10
+Using declarative-option 0.1.0
+Using unf_ext 0.0.7.4
+Using unf 0.1.4
+Using domain_name 0.5.20170404
+Using dotenv 2.2.1
+Using excon 0.60.0
+Using http-cookie 1.0.3
+Using faraday-cookie_jar 0.0.6
+Using faraday_middleware 0.12.2
+Using fastimage 2.1.1
+Using jwt 2.1.0
+Using little-plugger 1.1.4
+Using multi_json 1.13.1
+Using logging 2.2.2
+Using memoist 0.16.0
+Using os 0.9.6
+Using signet 0.8.1
+Using googleauth 0.6.2
+Using httpclient 2.8.3
+Using mime-types-data 3.2016.0521
+Using mime-types 3.1
+Using uber 0.1.0
+Using representable 3.0.4
+Using retriable 3.1.1
+Using google-api-client 0.13.6
+Using json 2.1.0
+Using mini_magick 4.5.1
+Using multi_xml 0.6.0
+Using plist 3.4.0
+Using rubyzip 1.2.1
+Using security 0.1.3
+Using slack-notifier 2.3.2
+Using terminal-notifier 1.8.0
+Using tty-screen 0.6.4
+Using tty-cursor 0.5.0
+Using tty-spinner 0.8.0
+Using word_wrap 1.0.0
+Using rouge 2.0.7
+Using xcpretty 0.2.8
+Using xcpretty-travis-formatter 1.0.0
+Using fastlane 2.79.0
+[32mBundle complete! 6 Gemfile dependencies, 96 gems now installed.[0m
+[32mBundled gems are installed into `/Users/administrator/gems`[0m
+[14:58:00]: [32m----------------------------------------[0m
+[14:58:00]: [32m--- Step: Verifying fastlane version ---[0m
+[14:58:00]: [32m----------------------------------------[0m
+[14:58:00]: Your fastlane version 2.79.0 matches the minimum requirement of 1.37.0  ✅
+[14:58:00]: [33mName of the lane 'build_app' is already taken by the action named 'build_app'[0m
+[14:58:00]: [32mDriving the lane 'mac staticAnalyze' 🚀[0m
+[14:58:00]: [32m--------------------------------[0m
+[14:58:00]: [32m--- Step: clear_derived_data ---[0m
+[14:58:00]: [32m--------------------------------[0m
+[14:58:00]: Derived Data path located at: /Users/administrator/Library/Developer/Xcode/DerivedData
+[14:58:03]: [32mSuccessfully cleared Derived Data ♻️[0m
+[14:58:03]: [32m------------------[0m
+[14:58:03]: [32m--- Step: scan ---[0m
+[14:58:03]: [32m------------------[0m
+[14:58:03]: [36m$ xcodebuild -list -workspace MindNode.xcworkspace[0m
+[14:58:05]: [36m$ xcodebuild -showBuildSettings -workspace MindNode.xcworkspace -scheme MindNode\ for\ macOS[0m
+[14:58:08]: [33mIt's not recommended to set the `destination` value directly[0m
+[14:58:08]: [33mInstead use the other options available in `fastlane scan --help`[0m
+[14:58:08]: [33mUsing your value 'platform=macOS' for now[0m
+[14:58:08]: [33mbecause I trust you know what you're doing...[0m
+[14:58:08]: [36m$ xcodebuild -list -workspace MindNode.xcworkspace[0m
+[14:58:10]: [36m$ xcodebuild -showBuildSettings -workspace MindNode.xcworkspace -scheme MindNode\ for\ macOS[0m
+[14:58:13]: [33mIt's not recommended to set the `destination` value directly[0m
+[14:58:13]: [33mInstead use the other options available in `fastlane scan --help`[0m
+[14:58:13]: [33mUsing your value 'platform=macOS' for now[0m
+[14:58:13]: [33mbecause I trust you know what you're doing...[0m
+
++------------------------+-------------------------------------------------------------------------------------------------------------+
+|                                                       [32mSummary for scan 2.79.0[0m                                                        |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+| workspace              | MindNode.xcworkspace                                                                                        |
+| scheme                 | MindNode for macOS                                                                                          |
+| xcargs                 | CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze |
+| derived_data_path      | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq              |
+| clean                  | false                                                                                                       |
+| skip_build             | false                                                                                                       |
+| output_directory       | ./fastlane/test_output                                                                                      |
+| output_types           | html,junit                                                                                                  |
+| buildlog_path          | ~/Library/Logs/scan                                                                                         |
+| include_simulator_logs | false                                                                                                       |
+| open_report            | false                                                                                                       |
+| skip_slack             | false                                                                                                       |
+| slack_only_on_failure  | false                                                                                                       |
+| use_clang_report_name  | false                                                                                                       |
+| fail_build             | true                                                                                                        |
+| xcode_path             | /Applications/Xcode.app                                                                                     |
++------------------------+-------------------------------------------------------------------------------------------------------------+
+
+[14:58:13]: [36m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace MindNode.xcworkspace -scheme MindNode\ for\ macOS -destination 'platform=macOS' -derivedDataPath '/Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq' CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' IDEBuildOperationMaxNumberOfConcurrentCompileTasks=1 analyze build test | tee '/Users/administrator/Library/Logs/scan/MindNode-MindNode for macOS.log' | xcpretty  --report html --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/fastlane/test_output/report.html' --report junit --output '/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/fastlane/test_output/report.junit' --report junit --output '/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/junit_report20180404-186-pj10rj'[0m
+[14:58:13]: ▸ [35mLoading...[0m
+[14:58:16]: [35m[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[14:58:16]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:16]: [35m[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist[0m
+[14:58:16]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m Archive.swift[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m Data+Compression.swift[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift[0m
+[14:58:25]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+[14:58:25]: ▸ [35mlet bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)[0m
+[14:58:25]: ▸ [35m[36m                                            ^[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m Entry.swift[0m
+[14:58:25]: [35m[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift[0m
+[14:58:27]: [35m[33m▸[0m [39;1mLinking[0m ZIPFoundation[0m
+[14:58:34]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m ZIPFoundation.framework[0m
+[14:58:34]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-macOS [Debug][0m
+[14:58:34]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging-macOS-dummy.m[0m
+[14:58:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogging.m[0m
+[14:58:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m[0m
+[14:58:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging-macOS-dummy.m[0m
+[14:58:34]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m[0m
+[14:58:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m[0m
+[14:58:35]: [35m[33m▸[0m [39;1mBuilding library[0m libMNCLogging-macOS.a[0m
+[14:58:35]: [35m[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug][0m
+[14:58:35]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:35]: [35m[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m Mappings.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m FontBuilder.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift[0m
+[14:58:35]: [35m[33m▸[0m [39;1mCompiling[0m Ashton.swift[0m
+[14:58:41]: [35m[33m▸[0m [39;1mCompiling[0m Ashton_vers.c[0m
+[14:58:43]: [35m[33m▸[0m [39;1mLinking[0m Ashton[0m
+[14:58:45]: [35m[33m▸[0m [39;1mCopying[0m Ashton.h[0m
+[14:58:48]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Ashton.framework[0m
+[14:58:48]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-macOS [Debug][0m
+[14:58:48]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m blocks.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m buffer.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m cmark-macOS-dummy.m[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m cmark.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m cmark_ctype.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m commonmark.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m houdini_href_e.c[0m
+[14:58:48]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_e.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m houdini_html_u.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m html.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m inlines.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m iterator.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m latex.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m man.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m node.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m references.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m render.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m scanners.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m utf8.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m xml.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m blocks.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m buffer.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark-macOS-dummy.m[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m commonmark.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m html.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m inlines.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m iterator.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m latex.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m man.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m node.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m references.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m render.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m scanners.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m utf8.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m xml.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mBuilding library[0m libcmark-macOS.a[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-macOS [Debug][0m
+[14:58:49]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser-macOS-dummy.m[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m CHCSVParser.m[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-macOS-dummy.m[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m[0m
+[14:58:49]: [35m[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-macOS.a[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[14:58:49]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:49]: [35m[33m▸[0m [39;1mProcessing[0m Info-macOS.plist[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_macOS.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m Receipt.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c[0m
+[14:58:49]: [35m[33m▸[0m [39;1mLinking[0m AppReceiptValidator[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m ssl3.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m pem2.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m mdc2.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m stack.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m err.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m pkcs7.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m asn1t.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m ui.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m asn1.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m buffer.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m x509.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m opensslv.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m crypto.h[0m
+[14:58:49]: [35m[33m▸[0m [39;1mCopying[0m kssl.h[0m
+[14:58:50]: [35m[33m▸[0m [39;1mCopying[0m cast.h[0m
+[14:58:50]: [35m[33m▸[0m [39;1mCopying[0m ssl.h[0m
+[14:58:51]: [35m[33m▸[0m [39;1mCopying[0m bn.h[0m
+[14:58:52]: [35m[33m▸[0m [39;1mCopying[0m rc4.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m tls1.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m camellia.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m rand.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m des_old.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m x509_vfy.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs12.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m evp.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m engine.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ssl23.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m modes.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m idea.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m x509v3.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m blowfish.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m aes.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m cmac.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m txt_db.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m dso.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m objects.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m dtls1.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m cms.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m dsa.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ssl2.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ripemd.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ts.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m conf.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m lhash.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m obj_mac.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ui_compat.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m rsa.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ec.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ecdsa.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m hmac.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m seed.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m whrlpool.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m bio.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ebcdic.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m dh.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m asn1_mac.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m des.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m krb5_asn.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m pqueue.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m rc2.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ossl_typ.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m srtp.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m srp.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m e_os2.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m opensslconf.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m md4.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ecdh.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m comp.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m safestack.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m symhacks.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m conf_api.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m ocsp.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m sha.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m pem.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m md5.h[0m
+[14:58:53]: [35m[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer[0m
+[14:58:53]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[14:58:54]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework[0m
+[14:58:54]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto macOS [Debug][0m
+[14:58:54]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:54]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c[0m
+[14:58:54]: [35m[33m▸[0m [39;1mLinking[0m CommonCrypto[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCopying[0m CommonCrypto_macOS.h[0m
+[14:58:54]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m CommonCrypto.framework[0m
+[14:58:54]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-macOS [Debug][0m
+[14:58:54]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Body.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Collision.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Contact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Distance.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Draw.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Island.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Joint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Math.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Rope.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Settings.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2Timer.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2World.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp[0m
+[14:58:54]: [35m[33m▸[0m [39;1mCompiling[0m box2d-macOS-dummy.m[0m
+[14:58:54]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp[0m
+[14:58:55]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2World.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp[0m
+[14:58:56]: [35m[33m▸[0m [39;1mAnalyzing[0m box2d-macOS-dummy.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mBuilding library[0m libbox2d-macOS.a[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m Shared/Shared macOS [Debug][0m
+[14:58:59]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:59]: [35m[33m▸[0m [39;1mProcessing[0m Shared-macOS-Info.plist[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Platform.swift[0m
+[14:58:59]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:58:59]: ▸ [35m#elseif (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:58:59]: ▸ [35m[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Observable.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Result.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Numbers.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m SupportLink.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction+Cocoa.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m WeakRef.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m DebugAction.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Defaults.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m DebugMenu.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m UserDebugging+macOS.swift[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m MNCMirror.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Shared_vers.c[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mLinking[0m Shared[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m MNCWeakArray.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m MNCMirror.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m MNFunctions.h[0m
+[14:58:59]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Shared.framework[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m Reachability/ReachabilityMac [Debug][0m
+[14:58:59]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:59]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Reachability.swift[0m
+[14:58:59]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+[14:58:59]: ▸ [35m#if (arch(i386) || arch(x86_64)) && os(iOS)[0m
+[14:58:59]: ▸ [35m[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m Reachability_vers.c[0m
+[14:58:59]: [35m[33m▸[0m [39;1mLinking[0m Reachability[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCopying[0m ReachabilityMac.h[0m
+[14:58:59]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Reachability.framework[0m
+[14:58:59]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug][0m
+[14:58:59]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:58:59]: [35m[33m▸[0m [39;1mProcessing[0m MindNodeQuickLookPlugIn-Info.plist[0m
+[14:58:59]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch[0m
+[14:58:59]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch[0m
+[14:58:59]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch[0m
+[14:58:59]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m GenerateThumbnailForURL.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m GeneratePreviewForURL.m[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[14:58:59]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m GenerateThumbnailForURL.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m GeneratePreviewForURL.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mLinking[0m MindNodeQuickLookPlugIn[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCopying[0m InfoPlist.strings[0m
+[14:59:00]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNodeQuickLookPlugIn.qlgenerator[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNodeSpotlightImporter [Debug][0m
+[14:59:00]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:00]: [35m[33m▸[0m [39;1mProcessing[0m MindNodeSpotlightImporter-Info.plist[0m
+[14:59:00]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch[0m
+[14:59:00]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch[0m
+[14:59:00]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch[0m
+[14:59:00]: [35m[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m main.c[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m GetMetadataForFile.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m main.c[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m GetMetadataForFile.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mLinking[0m MindNodeSpotlightImporter[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCopying[0m MindNodeSpotlightImporter/schema.xml[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCopying[0m InfoPlist.strings[0m
+[14:59:00]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNodeSpotlightImporter.mdimporter[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode Helper [Debug][0m
+[14:59:00]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m main.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m AppDelegate.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[14:59:00]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:59:00]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Helper.app[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for macOS Tests [Debug][0m
+[14:59:00]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:00]: [35m[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ macOS\ Tests-dummy.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ macOS\ Tests-dummy.m[0m
+[14:59:00]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ macOS\ Tests.a[0m
+[14:59:00]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode Quick Entry [Debug][0m
+[14:59:00]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:00]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[14:59:01]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:59:01]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:59:01]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[14:59:01]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[14:59:01]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[14:59:01]: [35m[33m▸[0m [39;1mCopying[0m Resources/Colors[0m
+[14:59:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXQuickEntryPopoverViewController.xib[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[14:59:03]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:59:03]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework[0m
+[14:59:03]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ Quick\ Entry.app[0m
+[14:59:03]: [35m[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing macOS [Debug][0m
+[14:59:03]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:03]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m SignedLicense.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m License.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m License+Products.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift[0m
+[14:59:03]: [35m[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m TrialState.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m Then.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumber.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c[0m
+[14:59:04]: [35m[33m▸[0m [39;1mLinking[0m Purchasing[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCopying[0m Purchasing_macOS.h[0m
+[14:59:04]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing.framework[0m
+[14:59:04]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for macOS [Debug][0m
+[14:59:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:04]: [35m[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ macOS-dummy.m[0m
+[14:59:04]: [35m[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ macOS-dummy.m[0m
+[14:59:04]: [35m[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ macOS.a[0m
+[14:59:04]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode for macOS [Debug][0m
+[14:59:04]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[14:59:04]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[14:59:04]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[14:59:05]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Purchasing/Purchasing/Service/PurchaseService.swift:542:9: [33mIdentifier Name Violation: Variable name should be between 3 and 40 characters long: 'upgradePathFromAdditionalDiscountedProduct' (identifier_name)[0m
+[14:59:05]: ▸ [35mLinting 'DataStoreTestContext.swift' (369/601)[0m
+[14:59:05]: ▸ [35m[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+[14:59:28]: [35m[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch[0m
+[14:59:33]: [35m[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch[0m
+[14:59:33]: [35m[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m[0m
+[14:59:34]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorViewController.m[0m
+[14:59:34]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorClipView.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXNumberFormatter.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeView.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindNodeSingleFileExportViewController.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXKeyCommand.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineBaseCellView.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m NSView+LayoutConstraintFiltering.m[0m
+[14:59:35]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCFileLink.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSWindow+FullScreen.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextAlignmentValueTransformer.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCHoverNodeState.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNCollectionView.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSString+UUID.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCNode.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNDefaults.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeView.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXClipView.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m[0m
+[14:59:37]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineRowView.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateNodeKnobState.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadDocumentViewController.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXOpenBrowserSharingService.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell+Bindings.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXShadowSeparatorContentView.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m[0m
+[14:59:38]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteIndicatorButton.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedControl.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineDataSource.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNCNote.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverManager.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontManager.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserItem.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m NSPopover+MNDetach.m[0m
+[14:59:39]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocument+Scripting.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathView.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m NSImage+MNAdditions.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXSheetWindowController.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorWell.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedControl.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNXPageSliderCell.m[0m
+[14:59:40]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCContent.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Alignment.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleController.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m NSSegmentedControl+MNAdditions.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m NSFontDescriptor+Convenience.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m[0m
+[14:59:41]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCAsset.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNFunctions.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCDevice.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeInteractionState.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNVector.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantButtonCell.m[0m
+[14:59:42]: [35m[33m▸[0m [39;1mCompiling[0m MNXAppDelegate.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXDraggingOperationState.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXLayoutManager.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeEditAccountWindowController.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXQuickLookController.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasView.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.m[0m
+[14:59:43]: [35m[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXTranslateCrossConnectionKnobState.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Insertion.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNXSidebarContainer.m[0m
+[14:59:44]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachment.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXSwitch.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXSingleAxisScrollView.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCExporter.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachableButtonCell.m[0m
+[14:59:45]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m NSApplication+LaunchServices.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageView.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCText.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m NSEvent+MNAdditions.m[0m
+[14:59:46]: [35m[33m▸[0m [39;1mCompiling[0m MNCTask.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeAccessoryButton.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m NSCursor+ObjectManipulationCursors.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXInspectorSectionViewController.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m NSPasteboard+Additions.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasInteractionState.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m NSBezierPath+MNCGPathRef.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesView.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXFoldingIndicatorButton.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNXThingsAppleScriptExporter.m[0m
+[14:59:47]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m NSValue+MNPlatformCompatibility.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorSwatchView.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m NSSharingService+MNXAdditions.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNXSanitizingTextView.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m[0m
+[14:59:48]: [35m[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasView.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadCompleteViewController.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXColorGridView.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarContainerView.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoOverlayView.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyMindNodePreferencesViewController.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m NSString+Paths.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNError.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m[0m
+[14:59:49]: [35m[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvas.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarButtonContainerView.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXRubberBandView.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineTableView.m[0m
+[14:59:50]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasPrintView.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersSharingService.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareLinkViewController.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m NSScrollView+ScrollingAdditions.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNXTaskButton.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m[0m
+[14:59:51]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextFinderClient.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArt.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m NSFont+Convenience.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNZooming.m[0m
+[14:59:52]: [35m[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXFunctions.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineCellView.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSearchCellView.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCKnobView.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareWindowController.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXCanvasViewController.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedCell.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m NSView+Animation.m[0m
+[14:59:53]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+NodeActions.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXScrollView.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXCreateNodeInteractionState.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegisterWindowController.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXAttachedTextField.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportViewController.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCTextController.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXSearchField.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionState.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXDemoLaunchWindowController.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserCell.m[0m
+[14:59:54]: [35m[33m▸[0m [39;1mCompiling[0m SSWZip.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNViewActions.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXCreateCrossConnectionState.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNXDragAndDropImageView.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m NSGraphicsContext+MNAdditions.m[0m
+[14:59:55]: [35m[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXResizableScrollView.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedCell.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextView.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageBrowserView.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeWellButton.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextEditor.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCycleNode.m[0m
+[14:59:56]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m main.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXView.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPDFExporter.m[0m
+[14:59:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorViewController.m[0m
+[14:59:58]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorClipView.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+ObjectsConvenience.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode+MNPropertyRepresentation.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNumberFormatter.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDateFormatter+MNAdditions.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeView.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMindNodeSingleFileExportViewController.m[0m
+[15:00:07]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme.m[0m
+[15:00:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXKeyCommand.m[0m
+[15:00:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument.m[0m
+[15:00:09]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Components.m[0m
+[15:00:09]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineBaseCellView.m[0m
+[15:00:09]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+LayoutConstraintFiltering.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersSyncController.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExtractCustomThemeWindowController.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFileLink.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSWindow+FullScreen.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineViewController.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextAlignmentValueTransformer.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHoverNodeState.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionView.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPastePersistentManager.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBranchRenderer.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m[0m
+[15:00:10]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutControllerManager.m[0m
+[15:00:11]: [35m[33m▸[0m [39;1mAnalyzing[0m NSIndexPath+MNCollectionView.m[0m
+[15:00:11]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+UUID.m[0m
+[15:00:11]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNode.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNDefaults.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+Stack.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCShapeStyle.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasView.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeView.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+MNAdditions.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXClipView.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCColorValueTransformer.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxy.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTranslateNodeController.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineRowView.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXShortcutsPreferencesViewController.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection+MNPropertyRepresentation.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTranslateNodeKnobState.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocument.m[0m
+[15:00:22]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadDocumentViewController.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOpenBrowserSharingService.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorWell+Bindings.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelectionController.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXShadowSeparatorContentView.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMarkdownExporter.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindParser.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNoteIndicatorButton.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedControl.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineDataSource.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNote.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToOmniFocusViewController.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverManager.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNAdditions.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFontManager.m[0m
+[15:00:23]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserItem.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m NSPopover+MNDetach.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageExporter.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocument+Scripting.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseTextExporter.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNode.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathView.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m NSImage+MNAdditions.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineLayouter.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSettingsViewController.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeRenderer.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSheetWindowController.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorWell.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedControl.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+CIELAB.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPageSliderCell.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController+box2dInterface.m[0m
+[15:00:24]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCContent.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Alignment.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleController.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFontSectionViewController.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleValue.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextView+MNAdditions.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText+MNPropertyRepresentation.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSegmentedControl+MNAdditions.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSFontDescriptor+Convenience.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFontStyle.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionKnobView.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerComposedDataSource.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+MNCProperties.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAsset.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDevice.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMainThreadHangDetector.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeInteractionState.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeStyle.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPathStyle.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNVector.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantButtonCell.m[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAppDelegate.m[0m
+[15:00:25]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/macOS/Sources/App Flow/MNXAppDelegate.m:77:64: [33mUser-facing text should use localized string macro[0m
+[15:00:25]: ▸ [35mnode.title = [[MNCText alloc] initWithAttributedString:[[NSAttributedString alloc] initWithString:@"Test"]];[0m
+[15:00:25]: ▸ [35m[36m                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[15:00:25]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDraggingOperationState.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeRepresentedObject.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseParser.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMigrationManager.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXLayoutManager.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeEditAccountWindowController.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXQuickLookController.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasView.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesWindowController.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCConvexHullController.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m NSTextAttachment+MNAdditions.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVParser.m[0m
+[15:00:26]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCIThoughtsParser.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTranslateCrossConnectionKnobState.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+QueryParsing.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindExporter.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAboutWindowController.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Insertion.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPlainTextExporter.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXStyleInspectorViewController.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyController.m[0m
+[15:00:35]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXGeneralPreferencesViewController.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineDefines.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRichTextExporter.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSidebarContainer.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMindjetParser.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBaseDataSource.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m NSParagraphStyle+MNConvenience.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachment.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSwitch.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXContentInspectorViewController.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLExporter.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUserGuideView.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImageAttachment.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCArrowStyle.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m NSData+Convenience.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPrintAccessoryViewController.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSingleAxisScrollView.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskSyncController.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCValueTransformerRegistration.m[0m
+[15:00:36]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCExporter.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAttachableButtonCell.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineTasksDataSource.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSApplication+LaunchServices.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme+Creation.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageView.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersViewController.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCloudShapeGenerator.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineSearchDataSource.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCText.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSEvent+MNAdditions.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTask.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeAccessoryButton.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSCursor+ObjectManipulationCursors.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInspectorSectionViewController.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOPMLParser.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineNodeCache.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSMutableAttributedString+Convenience.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m NSPasteboard+Additions.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeBorderSectionViewController.m[0m
+[15:00:37]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasInteractionState.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSBezierPath+MNCGPathRef.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m CAAnimation+MNCompletionBlocks.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesView.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFoldingIndicatorButton.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXThingsAppleScriptExporter.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas+MNPropertyRepresentation.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNoteSectionViewController.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInfoTextViewController.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPathStyleSectionViewController.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAttachmentRenderer.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSValue+MNPlatformCompatibility.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImagePickerViewController.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorSwatchView.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerContentDataSource.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m NSSharingService+MNXAdditions.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSanitizingTextView.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBranchRepresentedObject.m[0m
+[15:00:38]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSubselectionResizeKnobView.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNImporting.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasView.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAnalyticsTracker.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadCompleteViewController.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColorGridView.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarContainerView.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionRenderer.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDemoOverlayView.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToThingsViewController.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMyMindNodePreferencesViewController.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m NSString+Paths.m[0m
+[15:00:39]: [35m[33m▸[0m [39;1mAnalyzing[0m MNError.m[0m
+[15:00:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCLayoutManager.m[0m
+[15:00:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTheme1To2MigrationController.m[0m
+[15:00:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m[0m
+[15:00:40]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument4to5MigrationController.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvas.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetViewController.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarButtonContainerView.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNExporting.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFreemindExportViewController.m[0m
+[15:00:50]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXRubberBandView.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageExportViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineTableView.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasPrintView.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasRenderer.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXPDFExportViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersSharingService.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCAshtonValueTransformer.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMindMapSectionViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeShareLinkViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextExportViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCRemindersExporter.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSScrollView+ScrollingAdditions.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTaskButton.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtAttachment.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSURL+Convenience.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextOutlineParser.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextFinderClient.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOPMLExportViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStrokeStyle.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverViewController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArt.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m NSFont+Convenience.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXLeadingSidebarTabController.m[0m
+[15:00:51]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNodeDocument.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNZooming.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCClipArtSet.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCNodeWellButton.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXFunctions.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineCellView.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeShapeSectionViewController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCSVExporter.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCBaseStyle.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSearchCellView.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCKnobView.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeShareWindowController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTaskButton.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentObjectSavingManager.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCanvasViewController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedCell.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m NSView+Animation.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+NodeActions.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionStyle.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXScrollView.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCreateNodeInteractionState.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeRegisterWindowController.m[0m
+[15:00:52]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXAttachedTextField.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXExportViewController.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCTextController.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXSearchField.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPersistentImageManager.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXInteractionState.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDemoLaunchWindowController.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserCell.m[0m
+[15:00:53]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZip.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelection.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNViewActions.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController+Selection.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNSwizzling.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXCreateCrossConnectionState.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTrailingSidebarTabController.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Convenience.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSimpleXMLExporter.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDragAndDropImageView.m[0m
+[15:00:56]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCMindNodeExporter.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSGraphicsContext+MNAdditions.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCPasteboardController.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXResizableScrollView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedCell.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m NSObject+MNCoalescing.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCachingImageManager.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXNodeWellButton.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCUndoManager.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXTextEditor.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MTDXMLElement.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchToggleButton.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCycleNode.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m main.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCCanvasViewController.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchColorView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCResizeKnobView.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mAnalyzing[0m MNXMarkdownExportViewController.m[0m
+[15:00:57]: [35m[33m▸[0m [39;1mLinking[0m MindNode[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Pods/Target\ Support\ Files/Pods-MindNode\ for\ macOS/Pods-MindNode\ for\ macOS-acknowledgements.markdown[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m Resources/MindNode.sdef[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m Resources/Colors[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m Resources/Acknowledgements.rtf[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ macOS-metadata.plist[0m
+[15:00:58]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.xib[0m
+[15:00:59]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegisterWindowController.xib[0m
+[15:00:59]: [35m[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.xib[0m
+[15:00:59]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadCompleteViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeCollectionViewItem.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareWindowController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXThemeViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeEditAccountWindowController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXMindNodeSingleFileExportViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXMyMindNodePreferencesViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareLinkViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintOutlineTableView.xib[0m
+[15:01:00]: [35m[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowToolbarController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadDocumentViewController.xib[0m
+[15:01:01]: [35m[33m▸[0m [39;1mCompiling[0m MainMenu.xib[0m
+[15:01:04]: [35m[33m▸[0m [39;1mProcessing[0m MindNodeMac-Info.plist[0m
+[15:01:04]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNodeQuickLookPlugIn.qlgenerator[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNodeSpotlightImporter.mdimporter[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Reachability.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Ashton.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/AppReceiptValidator.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/ZIPFoundation.framework[0m
+[15:01:05]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[15:01:05]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[15:01:05]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Helper.app[0m
+[15:01:05]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app[0m
+[15:01:05]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[15:01:06]: [35m[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode for macOS Tests [Debug][0m
+[15:01:06]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:06]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[15:01:06]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[15:01:06]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[15:01:06]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[15:01:22]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+[15:01:22]: ▸ [35mlet polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }[0m
+[15:01:22]: ▸ [35m[36m                                                       ^[0m
+[15:01:22]: [35m[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCompiling[0m MNTextTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCompiling[0m NSDictionary+MNTestHelper.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCompiling[0m SSWZipTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCompiling[0m MNCStyleProxyTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mAnalyzing[0m MNTextTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNTestHelper.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mAnalyzing[0m SSWZipTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyTests.m[0m
+[15:01:31]: [35m[33m▸[0m [39;1mLinking[0m MindNode\[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/ExportNewDocument.applescript[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m WatchModel.plist[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap[0m
+[15:01:31]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md[0m
+[15:01:32]: [35m[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode[0m
+[15:01:32]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[15:01:32]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[15:01:32]: [35m[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'[0m
+[15:01:32]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode\ for\ macOS\ Tests.xctest[0m
+[15:01:32]: ▸ [35mThe following commands produced analyzer issues:[0m
+[15:01:32]: ▸ [35mAnalyze Sources/App\ Flow/MNXAppDelegate.m normal x86_64[0m
+[15:01:32]: ▸ [35m(1 command with analyzer issues)[0m
+[15:01:32]: [35m[33m▸[0m [39;1mAnalyze[0m Succeeded[0m
+[15:01:32]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug][0m
+[15:01:32]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:32]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[15:01:32]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:32]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug][0m
+[15:01:32]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:32]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[15:01:32]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:32]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeSpotlightImporter [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Helper [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Quick Entry [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[15:01:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS [Debug][0m
+[15:01:33]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:33]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[15:01:33]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[15:01:34]: ▸ [35m[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Purchasing/Purchasing/Service/PurchaseService.swift:542:9: [33mIdentifier Name Violation: Variable name should be between 3 and 40 characters long: 'upgradePathFromAdditionalDiscountedProduct' (identifier_name)[0m
+[15:01:34]: ▸ [35mLinting 'XCTestCase+ObservableAssertions.swift' (371/601)[0m
+[15:01:34]: ▸ [35m[36m                                                       ^~~~~~~[0m
+[15:01:34]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[15:01:35]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[15:01:35]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[15:01:35]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[15:01:35]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app[0m
+[15:01:35]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuild[0m Succeeded[0m
+[15:01:36]: ▸ [35m2018-04-04 15:01:36.188 xcodebuild[366:518559]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[15:01:36]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-E9023235-F910-4796-AFA3-4EAB72A88C81/MindNode for macOS Tests-C8D6BDF2-984C-47E3-A5E9-A58016A976BA/Session-MindNode for macOS Tests-2018-04-04_150136-iWKEid.log[0m
+[15:01:36]: ▸ [35m2018-04-04 15:01:36.189 xcodebuild[366:512580] [MT] IDETestOperationsObserverDebug: (86B4D351-31CC-427E-AE88-2D1931D5121E) Beginning test session MindNode for macOS Tests-86B4D351-31CC-427E-AE88-2D1931D5121E at 2018-04-04 15:01:36.189 with Xcode 9E145 on target <DVTLocalComputer: 0x7fdf7a304520 (My Mac | x86_64)> (10.13.4 (17E199))[0m
+[15:01:36]: ▸ [35m2018-04-04 15:01:36.193 xcodebuild[366:518559]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:[0m
+[15:01:36]: ▸ [35m/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-E9023235-F910-4796-AFA3-4EAB72A88C81/Purchasing Tests macOS-ACC9AD36-EF2E-4990-87DE-0B7861FF4581/Session-Purchasing Tests macOS-2018-04-04_150136-KtxOCk.log[0m
+[15:01:36]: ▸ [35m2018-04-04 15:01:36.193 xcodebuild[366:512580] [MT] IDETestOperationsObserverDebug: (1F5DF392-C3B1-4A80-A4B4-2C7FC415B0E4) Beginning test session Purchasing Tests macOS-1F5DF392-C3B1-4A80-A4B4-2C7FC415B0E4 at 2018-04-04 15:01:36.193 with Xcode 9E145 on target <DVTLocalComputer: 0x7fdf7a304520 (My Mac | x86_64)> (10.13.4 (17E199))[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug][0m
+[15:01:36]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:36]: [35m[33m▸[0m [39;1mRunning script[0m 'Swiftlint'[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeSpotlightImporter [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Helper [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS Tests [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Quick Entry [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[15:01:37]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo macOS [Debug][0m
+[15:01:37]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:37]: [35m[33m▸[0m [39;1mCompiling[0m ViewController.swift[0m
+[15:01:37]: [35m[33m▸[0m [39;1mCompiling[0m AppDelegate.swift[0m
+[15:01:37]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[15:01:37]: [35m[33m▸[0m [39;1mCompiling[0m Main.storyboard[0m
+[15:01:38]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[15:01:38]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework[0m
+[15:01:38]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework[0m
+[15:01:38]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ macOS.app[0m
+[15:01:38]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS [Debug][0m
+[15:01:38]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Preflight Script'[0m
+[15:01:38]: [35m[33m▸[0m [39;1mRunning script[0m 'Postflight Script'[0m
+[15:01:39]: [35m[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app[0m
+[15:01:40]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m MindNode.app[0m
+[15:01:40]: [35m[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests macOS [Debug][0m
+[15:01:40]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:40]: [35m[33m▸[0m [39;1mProcessing[0m Info.plist[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m VersionNumberTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m ReceiptAssets.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m MockPurchasingServiceConfiguration.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m XCTestCase+ObservableAssertions.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdaterTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m TestAssetLoading.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m LicenseAssets.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m License+Convenience.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m LicenseValidatorTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m SignatureVerifierTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m CurrentReceiptValidationTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysisTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m MockDefaults.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m Date+Convenience.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+Convenience.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m DataStoreTestContext.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTestContext.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStoreTests.swift[0m
+[15:01:40]: [35m[33m▸[0m [39;1mCompiling[0m PurchaseServiceTests.swift[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCompiling[0m MockStorePromotionControllerWrapper.swift[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCompiling[0m Receipt+DemoData.swift[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCompiling[0m MockStoreKitWrapper.swift[0m
+[15:01:41]: [35m[33m▸[0m [39;1mLinking[0m Purchasing\[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/wildcard.alamofire.org.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.2.3.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-root-ca.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity01[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/expired.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-dns-name.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial_and_full.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity02[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/missing-dns-name-and-uri.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01.txt[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_3394.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithoutTrial_SignedWithProduction.json[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity02_rsaCert.der[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-uri.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial_and_fullversion.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_michaelsandbox_receipt1.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_147.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicenseWithTrial_With_Identity01.json[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity02[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity01[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicense_With_Identity01.json[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/MindNodeLicensingProduction_rsaCert.der[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_vpp.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca2.cer[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.5.7.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_fullversionfree.b64[0m
+[15:01:41]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca1.cer[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/test.alamofire.org.cer[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_vpp.b64[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02.txt[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/multiple-dns-names.cer[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca1.cer[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial.b64[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithTrial_SignedWithProduction.json[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca2.cer[0m
+[15:01:42]: [35m[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity01_rsaCert.der[0m
+[15:01:42]: [35mRunning Tests: [33m▸[0m [39;1mTouching[0m Purchasing\ Tests\ macOS.xctest[0m
+[15:01:42]: [35m[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS Tests [Debug][0m
+[15:01:42]: [35m[33m▸[0m [39;1mCheck Dependencies[0m
+[15:01:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'[0m
+[15:01:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'[0m
+[15:01:42]: [35m[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'[0m
+[15:01:42]: [35m[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'[0m
+[15:01:43]: ▸ [35m[39;1mAll tests[0m
+[15:01:43]: ▸ [35mTest Suite [39;1mMindNode for macOS Tests.xctest[0m started[0m
+[15:01:43]: ▸ [35m[39;1mMNCCSVExporterTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCounterOfLevels ([31m0.360[0m seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCSV (0.023 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCSVisNotEmpty (0.022 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testHeader (0.022 seconds)[0m
+[15:01:43]: ▸ [35m[39;1mMNCCSVImporterTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testImport (0.019 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testMainNodes (0.017 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testStructure (0.016 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testTotalNodes (0.016 seconds)[0m
+[15:01:43]: ▸ [35m[39;1mMNCCanvasControllerTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCanvasControllerSetup (0.022 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testInsertParentNode ([33m0.054[0m seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testRemoveAllNodes ([33m0.027[0m seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testRemoveNode ([33m0.028[0m seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testRemoveNodeAndSubnodes (0.023 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testRepresentedObject ([33m0.027[0m seconds)[0m
+[15:01:43]: ▸ [35m[39;1mMNCCanvasSelectionControllerTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCanvasSelectionConvenienceGetters (0.004 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCanvasSelectionEqualsSelectionController (0.003 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testCanvasSelectionGetsResetAfterSelectionChange (0.003 seconds)[0m
+[15:01:43]: ▸ [35m[39;1mMNCCanvasTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testAddNode (0.001 seconds)[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testRemoveAllNodes (0.001 seconds)[0m
+[15:01:43]: ▸ [35m[39;1mMNCCollisionControllerTests[0m
+[15:01:43]: ▸ [35m[32;1m✓[0m testBoundsCollision ([33m0.061[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testMindMapControllerSelectionMovement ([33m0.087[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testRectHitTest ([33m0.042[0m seconds)[0m
+[15:01:44]: ▸ [35m[39;1mMNCDocument4to5MigrationControllerTests[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testMigration (0.018 seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testTextMigration (0.021 seconds)[0m
+[15:01:44]: ▸ [35m[39;1mMNCDocument5to6MigrationControllerTests[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testMigration ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[39;1mMNCDocumentKVOControllerTests[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testNearestMindMapObject ([33m0.041[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault ([33m0.031[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleDefault ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleLeft ([33m0.029[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleManual ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleRight ([33m0.029[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight ([33m0.030[0m seconds)[0m
+[15:01:44]: ▸ [35m[32;1m✓[0m testSortingTaskStateRightAligned (0.023 seconds)[0m
+[15:01:44]: ▸ [35m[39;1mMNCDocumentOpenPerformanceTests[0m
+[15:01:55]: ▸ [35m[33m◷[0m testLargeMindMapWithTasks measured ([31m1.024[0m seconds)[0m
+[15:01:55]: ▸ [35m[32;1m✓[0m testLargeMindMapWithTasks ([31m10.599[0m seconds)[0m
+[15:02:12]: ▸ [35m[33m◷[0m testMindMapWithLotsOfCrossConnections measured ([31m1.656[0m seconds)[0m
+[15:02:12]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfCrossConnections ([31m16.999[0m seconds)[0m
+[15:02:44]: ▸ [35m[33m◷[0m testMindMapWithLotsOfNodes measured ([31m3.170[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testMindMapWithLotsOfNodes ([31m32.272[0m seconds)[0m
+[15:02:44]: ▸ [35m[39;1mMNCDocumentTests[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithUnsupportedVersionNumbers (0.017 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion1 ([33m0.027[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion2 ([33m0.030[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion3 ([33m0.030[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion4 ([33m0.036[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion5 ([33m0.033[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocumentWithVersion6 ([33m0.042[0m seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpeningEmptyDocument (0.016 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenMindNodeTouchDocument (0.011 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testResolvingSecurityScopedBookmark ([33m0.033[0m seconds)[0m
+[15:02:44]: ▸ [35m[39;1mMNCDocumentVersionDecisionTests[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testExport (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testNewDocument (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testOpenDocument (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[39;1mMNCFontExtractorTests[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testCompoundEmoji (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testEmoji (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testEmptyString (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testFontStyle (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testFullyEmojiString (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testFullySymbolic (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testFullySymbolicAndEmojiString (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testNormalFont (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testSymbol (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testSymbolAndEmoji (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testSymbolWithWrongFont (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[39;1mMNCFontManagerTests[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion1 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion10 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion100 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion11 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion12 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion13 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion14 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion15 (0.016 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion16 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion17 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion18 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion19 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion2 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion20 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion21 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion22 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion23 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion24 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion25 (0.010 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion26 (0.003 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion27 (0.010 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion28 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion29 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion3 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion30 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion31 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion32 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion33 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion34 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion35 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion36 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion37 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion38 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion39 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion4 (0.012 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion40 (0.007 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion41 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion42 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion43 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion44 (0.010 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion45 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion46 (0.010 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion47 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion48 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion49 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion5 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion50 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion51 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion52 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion53 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion54 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion55 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion56 (0.003 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion57 (0.014 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion58 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion59 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion6 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion60 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion61 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion62 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion63 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion64 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion65 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion66 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion67 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion68 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion69 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion7 (0.006 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion70 (0.004 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion71 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion72 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion73 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion74 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion75 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion76 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion77 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion78 (0.001 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion79 (0.002 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion8 (0.005 seconds)[0m
+[15:02:44]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion80 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion81 (0.012 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion82 (0.004 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion83 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion84 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion85 (0.003 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion86 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion87 (0.005 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion88 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion89 (0.003 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion9 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion90 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion91 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion92 (0.004 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion93 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion94 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion95 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion96 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion97 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion98 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testRandomGeneratedFontConversion99 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily1 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily2 (0.002 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily3 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily4 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily5 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily6 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily1 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily10 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily11 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily12 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily13 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily14 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily2 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily3 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily4 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily5 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily6 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily7 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily8 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily9 (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[39;1mMNCFontStyleTests[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testAttributedStringInit (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testNilInit (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testNodeRewire ([33m0.054[0m seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testNormalInit (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[32;1m✓[0m testSymbolCharacter (0.001 seconds)[0m
+[15:02:45]: ▸ [35m[39;1mMNCFreeMindImporterTests[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testBranchWidth ([31m2.016[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testBubbleShape ([33m0.087[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testCustomTitleColor ([33m0.084[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testImport ([33m0.085[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testLinks ([33m0.084[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testMainNodeHasPillShape ([33m0.083[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testNodeAlignment ([33m0.088[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testNodeAttributedTitle ([33m0.083[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testNodeTitle ([33m0.084[0m seconds)[0m
+[15:02:47]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.083[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testParsesBranchColor ([33m0.085[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testShapeFillColor ([33m0.085[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testSpecialCharactersDecoding (0.014 seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreConnectingCorrectNodes ([33m0.083[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsAreImported ([33m0.086[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatCrossConnectionsHaveCorrectColor ([33m0.085[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatFoldingIsRespected ([33m0.084[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatFontNamesAreParsed ([33m0.085[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatFontSizesAreParsed ([33m0.084[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatNodesDeriveBubbleStyleFromParent ([33m0.084[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleCanOverrideFillColor ([33m0.084[0m seconds)[0m
+[15:02:48]: ▸ [35m[32;1m✓[0m testThatNodesDerivedBubbleStyleDoesntHaveDerivedFillColor ([33m0.087[0m seconds)[0m
+[15:02:49]: ▸ [35m[32;1m✓[0m testThatNotesAreImported ([31m0.167[0m seconds)[0m
+[15:02:49]: ▸ [35m[32;1m✓[0m testThatParsesForkStyle ([33m0.084[0m seconds)[0m
+[15:02:49]: ▸ [35m[39;1mMNCFunctionsTests[0m
+[15:02:49]: ▸ [35m[32;1m✓[0m testCGFloatEquality (0.001 seconds)[0m
+[15:02:49]: ▸ [35m[32;1m✓[0m testStringByRemovingCharactersInSet (0.001 seconds)[0m
+[15:02:49]: ▸ [35m[39;1mMNCHelloPayloadBuilderTests[0m
+[15:02:49]: ▸ [35m[32;1m✓[0m testPayloadConstruction (0.002 seconds)[0m
+[15:02:49]: ▸ [35m[39;1mMNCImageExporterTests[0m
+[15:02:52]: ▸ [35m[32;1m✓[0m testImageRepresentation ([31m2.907[0m seconds)[0m
+[15:02:55]: ▸ [35m[32;1m✓[0m testImageRepresentationWithoutBackground ([31m3.358[0m seconds)[0m
+[15:02:58]: ▸ [35m[32;1m✓[0m testImageRepresentationWithPadding ([31m2.637[0m seconds)[0m
+[15:03:08]: ▸ [35m[32;1m✓[0m testImageRepresentationWithScaling ([31m10.326[0m seconds)[0m
+[15:03:08]: ▸ [35m[39;1mMNCInsertPositionCalculatorTests[0m
+[15:03:08]: ▸ [35m[32;1m✓[0m testInsertionOfSiblingsAboveAndBelow (0.003 seconds)[0m
+[15:03:08]: ▸ [35m[32;1m✓[0m testInsertPositionForManualLeftRightLayout (0.003 seconds)[0m
+[15:03:08]: ▸ [35m[32;1m✓[0m testInsertPositionForTopDownLayout (0.003 seconds)[0m
+[15:03:08]: ▸ [35m[39;1mMNCLayoutCalculatorTests[0m
+[15:03:08]: ▸ [35m[32;1m✓[0m testHorizontalLayout (0.004 seconds)[0m
+[15:03:09]: ▸ [35m[33m◷[0m testHorizontalLayoutCalculationPerformance measured (0.015 seconds)[0m
+[15:03:09]: ▸ [35m[32;1m✓[0m testHorizontalLayoutCalculationPerformance ([31m1.442[0m seconds)[0m
+[15:03:09]: ▸ [35m[32;1m✓[0m testLayoutForLargeSupernodes (0.002 seconds)[0m
+[15:03:09]: ▸ [35m[32;1m✓[0m testVerticalLayout (0.004 seconds)[0m
+[15:03:11]: ▸ [35m[33m◷[0m testVerticalLayoutCalculationPerformance measured (0.015 seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testVerticalLayoutCalculationPerformance ([31m1.417[0m seconds)[0m
+[15:03:11]: ▸ [35m[39;1mMNCLayoutControllerTests[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testDefaultLayoutControllerDeterminism (0.023 seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange0 ([33m0.091[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange1 ([31m0.120[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange2 ([33m0.078[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange3 ([33m0.078[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange4 ([33m0.080[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testLayoutStyleChange5 ([31m0.101[0m seconds)[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testThatLeftRightComputesTheSameAsReference ([33m0.092[0m seconds)[0m
+[15:03:11]: ▸ [35m[39;1mMNCMarkdownImporterTests[0m
+[15:03:11]: ▸ [35m[32;1m✓[0m testContent ([33m0.037[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([33m0.048[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.036[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testStructure ([33m0.036[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testTodos ([33m0.036[0m seconds)[0m
+[15:03:12]: ▸ [35m[39;1mMNCMindJetImporterTests[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.119[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testExportedBackgroundColor ([31m0.227[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testExportedNodeTextFormatting ([31m0.222[0m seconds)[0m
+[15:03:12]: ▸ [35m[32;1m✓[0m testHyperlinks ([33m0.092[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testImages ([31m0.353[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testImport ([33m0.091[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNodeAlignment ([33m0.094[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNodeFormatting ([33m0.092[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNodeText ([33m0.092[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([33m0.092[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNotes ([33m0.092[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNotesAndHyperlinkOnSameNode ([33m0.091[0m seconds)[0m
+[15:03:13]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.092[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testTaskStatus ([31m0.223[0m seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCMindMapTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testImportWithInvalidLayoutStyle (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCMyMindNodeTokenStoreTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testMyMindNodeKeyRetrieval (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testTokenStoring (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCNodeControllerTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testParsingOfNodeDataFromTitle (0.003 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCNodeHierarchyTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testEmptyNodeHierarchy (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testManualNodeHierarchy (0.003 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testNodeHierarchyOfOpenedDocument ([33m0.090[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testNodeRewire ([31m0.109[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testNodeRewireWith2MindMaps ([33m0.077[0m seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCNodeLayoutCalculatorTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testNodeLayoutCalculation (0.002 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCOPMLImporterTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.028[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testSpecialSingleChildCase (0.015 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testStructure ([33m0.027[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testTasks ([33m0.028[0m seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCPasteboardTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testCanvasObjectPasteboardParserRoundTrip ([31m0.147[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testEmptyPasteboard (0.013 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardCanvasObject (0.004 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardController ([31m0.149[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardCrossConnectionStyle (0.003 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardEmptyString (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardFontStyle (0.002 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardImage ([33m0.084[0m seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardNodeStyle (0.002 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testPasteboardString (0.006 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCPropertyRepresentationTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testV6PropertyRepresentation ([33m0.038[0m seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCSetSynchronizerTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testInitialSyncMerging (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurAddition (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurAdditionTheirAddition (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurAdditionTheirRemoval (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurRemoval (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurRemovalTheirAddition (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testOurRemovalTheirRemoval (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testSyncFailureRollback (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testThatInvalidStateExceptionIsThrown (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testTheirAddition (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testTheirRemoval (0.001 seconds)[0m
+[15:03:14]: ▸ [35m[39;1mMNCSpotlightImporterTests[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testSpotlightIndexerForUnsupportedDocumentVersion (0.003 seconds)[0m
+[15:03:14]: ▸ [35m[32;1m✓[0m testV4SpotlightIndexerForValidDocument (0.003 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForBigDocument ([33m0.069[0m seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForEmptyDocument (0.002 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerForValidDocument (0.005 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithCrossConnectionTitle (0.003 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV5SpotlightIndexerWithNotes (0.002 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testV6SpotlightIndexer (0.003 seconds)[0m
+[15:03:15]: ▸ [35m[39;1mMNCStyleDocument1to2MigrationTests[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testThatStyleDocumentUpgradeAndDowngradeResultsInOriginalStyleDocument (0.006 seconds)[0m
+[15:03:15]: ▸ [35m[39;1mMNCStyleProxyTests[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testBoxing (0.016 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testKeyPathAccess (0.013 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testStyleProxyObjectUpdate (0.014 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testTextManipulation ([33m0.039[0m seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testTextSpecialCase (0.020 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testThatRemovingLastObjectResultsInEmptyStyleProxy (0.012 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testThatRemovingOfValuesResultsInCorrectStyleValue (0.014 seconds)[0m
+[15:03:15]: ▸ [35m[32;1m✓[0m testValueTransformer (0.015 seconds)[0m
+[15:03:15]: ▸ [35m[39;1mMNCTaskControllerTest[0m
+[15:03:22]: ▸ [35m[33m◷[0m testActivatingDeactivatingTaskStatePerformance measured ([31m0.597[0m seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testActivatingDeactivatingTaskStatePerformance ([31m7.358[0m seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testMultipleTaskSettingOnDeepTree (0.003 seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testProgressCalculationOnDeepTree (0.003 seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testProgressCalculationOnFlatTree (0.002 seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnDeepTree (0.003 seconds)[0m
+[15:03:22]: ▸ [35m[32;1m✓[0m testRefreshOfStatesOnFlatTree (0.002 seconds)[0m
+[15:03:24]: ▸ [35m[33m◷[0m testRefreshPerformance measured (0.025 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testRefreshPerformance ([31m1.572[0m seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testShowTaskControlOnFlatTree (0.002 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTaskCreationViaTitle (0.004 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTaskPropagationOnDeepTree (0.002 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTaskPropagationOnFlatTree (0.002 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTogglingNodeStatesOnFlatTree (0.002 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTogglingOfCompletionStateOnDeepTree (0.003 seconds)[0m
+[15:03:24]: ▸ [35m[32;1m✓[0m testTogglingOfTaskStatesOnDeepTree (0.003 seconds)[0m
+[15:03:27]: ▸ [35m[33m◷[0m testTogglingTaskStatePerformance measured ([31m0.256[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testTogglingTaskStatePerformance ([31m3.901[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testUndoTaskToggleOnDeepTree (0.004 seconds)[0m
+[15:03:28]: ▸ [35m[39;1mMNCTaskPaperExporterTests[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testTaskPaperExport ([33m0.040[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testTaskPaperExportWithOmniFocusConfiguration ([33m0.041[0m seconds)[0m
+[15:03:28]: ▸ [35m[39;1mMNCTaskPaperImporterTests[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testInlineTags ([33m0.031[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testNotes ([33m0.030[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.030[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testStructure ([33m0.031[0m seconds)[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testTasks ([33m0.030[0m seconds)[0m
+[15:03:28]: ▸ [35m[39;1mMNCTextBundleExporterTests[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testBundleContent ([33m0.068[0m seconds)[0m
+[15:03:28]: ▸ [35m[39;1mMNCTextBundleImporterTests[0m
+[15:03:28]: ▸ [35m[32;1m✓[0m testExportImportRoundTrip ([31m0.559[0m seconds)[0m
+[15:03:29]: ▸ [35m[32;1m✓[0m testImportOfTextBundleFile ([31m0.145[0m seconds)[0m
+[15:03:29]: ▸ [35m[39;1mMNCTextExporterTests[0m
+[15:03:29]: ▸ [35m[32;1m✓[0m testNodeOrderOfPlainTextExport ([33m0.089[0m seconds)[0m
+[15:03:29]: ▸ [35m[39;1mMNCTextOutlineImporterTests[0m
+[15:03:30]: ▸ [35m[31m✗[0m testPasteboard, failed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x6040032466c0> was mutated while being enumerated."[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testPlainTextImport ([31m0.351[0m seconds)[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testRichTextImport ([31m0.317[0m seconds)[0m
+[15:03:30]: ▸ [35m[39;1mMNCTheme2to3MigrationTests[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithColor (0.007 seconds)[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testPartialNodeStyleWithNode (0.007 seconds)[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testThatThemeUpgradeAndDowngradeResultsInOriginalTheme (0.009 seconds)[0m
+[15:03:30]: ▸ [35m[39;1mMNCThemeDataSourceTests[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testThemeOrder (0.001 seconds)[0m
+[15:03:30]: ▸ [35m[39;1mMNCThemeManagerTests[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testAddTheme (0.012 seconds)[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testRemoveTheme (0.011 seconds)[0m
+[15:03:30]: ▸ [35m[32;1m✓[0m testStandardThemes (0.001 seconds)[0m
+[15:03:30]: ▸ [35m[39;1mMNCThemeTests[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testThemePreviewImageGeneration ([31m0.378[0m seconds)[0m
+[15:03:31]: ▸ [35m[39;1mMNCThingsExporterTests[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testExportURLGenertion ([33m0.062[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testJSONDataExport ([33m0.057[0m seconds)[0m
+[15:03:31]: ▸ [35m[39;1mMNCXMindImporterTests[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testBackgroundColor ([33m0.082[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testContent ([33m0.046[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testCrossConnections ([33m0.051[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testLinks ([33m0.054[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([33m0.047[0m seconds)[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testStructure ([33m0.056[0m seconds)[0m
+[15:03:31]: ▸ [35m[39;1mMNCXMindStyleImporterTest[0m
+[15:03:31]: ▸ [35m[32;1m✓[0m testBorder ([31m0.239[0m seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testBorderLineWidth ([31m0.198[0m seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testColor ([31m0.198[0m seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testCrossConnectionStyle ([31m0.200[0m seconds)[0m
+[15:03:32]: ▸ [35m[39;1mMNCZoomingCalculatorTests[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testCalculatorZoomIn (0.001 seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testCalculatorZoomOut (0.001 seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testCalculatorZoomScaleEqual (0.001 seconds)[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testDifferentInsets (0.001 seconds)[0m
+[15:03:32]: ▸ [35m[39;1mMNCiThoughtsImporterTests[0m
+[15:03:32]: ▸ [35m[32;1m✓[0m testBoundariesV4 ([33m0.099[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testCrossConnections ([31m0.415[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testCrossConnectionsV3 ([33m0.080[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testCrossConnectionsV4 ([33m0.098[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testHyperlinks ([31m0.418[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testHyperlinksV3 ([33m0.077[0m seconds)[0m
+[15:03:33]: ▸ [35m[32;1m✓[0m testHyperlinksV4 ([33m0.099[0m seconds)[0m
+[15:03:34]: ▸ [35m[32;1m✓[0m testImages ([31m0.677[0m seconds)[0m
+[15:03:34]: ▸ [35m[32;1m✓[0m testImport ([31m0.400[0m seconds)[0m
+[15:03:35]: ▸ [35m[32;1m✓[0m testImportV3 ([33m0.077[0m seconds)[0m
+[15:03:35]: ▸ [35m[32;1m✓[0m testImportV4 ([33m0.095[0m seconds)[0m
+[15:03:35]: ▸ [35m[32;1m✓[0m testLayoutStyle ([31m0.407[0m seconds)[0m
+[15:03:35]: ▸ [35m[32;1m✓[0m testLayoutStyleV3 ([31m0.406[0m seconds)[0m
+[15:03:36]: ▸ [35m[32;1m✓[0m testLineTypeV4 ([33m0.096[0m seconds)[0m
+[15:03:36]: ▸ [35m[32;1m✓[0m testNodeAlignment ([31m0.406[0m seconds)[0m
+[15:03:36]: ▸ [35m[32;1m✓[0m testNodeAlignmentV3 ([33m0.078[0m seconds)[0m
+[15:03:36]: ▸ [35m[32;1m✓[0m testNodeAlignmentV4 ([33m0.097[0m seconds)[0m
+[15:03:37]: ▸ [35m[32;1m✓[0m testNodeFormatting ([31m0.405[0m seconds)[0m
+[15:03:37]: ▸ [35m[32;1m✓[0m testNodeFormattingV3 ([33m0.079[0m seconds)[0m
+[15:03:37]: ▸ [35m[32;1m✓[0m testNodeFormattingV4 ([33m0.096[0m seconds)[0m
+[15:03:37]: ▸ [35m[32;1m✓[0m testNodeText ([31m0.413[0m seconds)[0m
+[15:03:38]: ▸ [35m[32;1m✓[0m testNodeTextFormatting ([31m0.404[0m seconds)[0m
+[15:03:38]: ▸ [35m[32;1m✓[0m testNodeTextV3 ([33m0.079[0m seconds)[0m
+[15:03:38]: ▸ [35m[32;1m✓[0m testNodeTextV4 ([33m0.098[0m seconds)[0m
+[15:03:38]: ▸ [35m[32;1m✓[0m testNotes ([31m0.410[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testNumberOfNodes ([31m0.406[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testNumberOfNodesV3 ([33m0.077[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testNumberOfNodesV4 ([33m0.096[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testTasks ([31m0.415[0m seconds)[0m
+[15:03:39]: ▸ [35m[39;1mMNColorTests[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testBlackWhiteComplementColor (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testColorComponentRetrieval (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testDarkenedColor (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testDerivedColor (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testLightenedColor (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testPropertyRepInit (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testRGBComplementColor (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testWebColorString3Init (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testWebColorString6Init (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testWebColorString8Init (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[39;1mMNTextTests[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testApplyStyle ([33m0.027[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testApplyStyleInRange (0.004 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testEditing (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testEmptyInit (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testFindString (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testInit (0.002 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testSavingAndLoadingOfStringWithSpecialControlCharacters (0.002 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testSetString (0.002 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testTextWithAttributes (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testTextWithFont ([33m0.074[0m seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testTextWithFontMonospaced ([33m0.057[0m seconds)[0m
+[15:03:39]: ▸ [35m[39;1mMNXBetaControllerTests[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testBetaInformationEncryption (0.002 seconds)[0m
+[15:03:39]: ▸ [35m[39;1mMNXOpenURLRouteTests[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testBetaActivationRoute (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[32;1m✓[0m testPurchaseRoute (0.001 seconds)[0m
+[15:03:39]: ▸ [35m[39;1mMNXScriptingTests[0m
+[15:03:40]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsCSV ([31m0.929[0m seconds)[0m
+[15:03:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsDocX ([31m0.520[0m seconds)[0m
+[15:03:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsFreeMind ([31m0.306[0m seconds)[0m
+[15:03:41]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsMarkdown ([31m0.443[0m seconds)[0m
+[15:03:42]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsMSFF ([31m0.450[0m seconds)[0m
+[15:03:43]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsOPML ([31m0.572[0m seconds)[0m
+[15:03:43]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsPDF ([31m0.316[0m seconds)[0m
+[15:03:43]: ▸ [35m[32;1m✓[0m testExportNewDocumentAsPNG ([31m0.459[0m seconds)[0m
+[15:03:43]: ▸ [35m[39;1mMorphingTests[0m
+[15:03:43]: ▸ [35m[32;1m✓[0m testNormalization (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[33m◷[0m testPerformance measured ([31m0.206[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testPerformance ([31m2.651[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testSimpleInsert (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testSimpleMatch (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testSimpleMorph (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[39;1mNSAttributedStringMarkdownTests[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testBoldItalic (0.002 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testBoldMarkdownConversion (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testCombiningAttributes (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testItalicMarkdownConversion (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testLinkConversion (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testParagraphs (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testPlainTextConversion (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testStrikethroughConversion (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[39;1mNSRangeSwiftTests[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testFullRange (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testSubStringFromIndex (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testSubStringFromRange (0.001 seconds)[0m
+[15:03:46]: ▸ [35m[39;1mSSWZipTests[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testAddCompressedEntry (0.024 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testAddSymbolicLink (0.009 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testAddUncompressedEntry (0.020 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testCreateCompressedArchive (0.007 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testCreateNestedDirectoryStrucutre (0.009 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testCreateUncompressedArchive (0.007 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testDetectionOfUnspportedFormatFeatures ([33m0.028[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testLastModFileDate (0.009 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testLastModFileTime (0.009 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testNonUnixOSTypes (0.008 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testPosixPermissions (0.010 seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testRemoveCompressedEntry ([33m0.050[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testRemoveUncompressedEntry ([33m0.040[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToData ([33m0.056[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedEntryToURL ([33m0.035[0m seconds)[0m
+[15:03:46]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderArchive (0.006 seconds)[0m
+[15:03:47]: ▸ [35m[33m◷[0m testUnzipCompressedFolderEntries measured (0.003 seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipCompressedFolderEntries ([31m0.332[0m seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipItemAtURL ([33m0.042[0m seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipItemAtURLErrorConditions (0.006 seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToData (0.013 seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedEntryToURL (0.014 seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderArchive (0.006 seconds)[0m
+[15:03:47]: ▸ [35m[32;1m✓[0m testUnzipUncompressedFolderEntries (0.019 seconds)[0m
+[15:03:48]: ▸ [35m[33m◷[0m testZipDirectoryContentsAtURL measured ([33m0.074[0m seconds)[0m
+[15:03:48]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURL ([31m1.005[0m seconds)[0m
+[15:03:48]: ▸ [35m[32;1m✓[0m testZipDirectoryContentsAtURLErrorConditions (0.006 seconds)[0m
+[15:03:48]: ▸ [35mMindNode_for_macOS_Tests.MNCTextOutlineImporterTests[0m
+[15:03:48]: ▸ [35mtestPasteboard, [31mfailed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x6040032466c0> was mutated while being enumerated."[0m
+[15:03:48]: ▸ [35m[36m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCTextOutlineImporterTests.swift:36[0m
+[15:03:48]: ▸ [35m```[0m
+[15:03:48]: ▸ [35m[38;5;230m            [39m[38;5;221;01mlet[39;00m[38;5;230m [39m[38;5;153;01mmainNode[39;00m[38;5;230m [39m[38;5;87m=[39m[38;5;230m [39m[38;5;230mdocument[39m[38;5;87m.[39m[38;5;230mcanvas[39m[38;5;87m.[39m[38;5;230mmindMaps[39m[38;5;87m[[39m[38;5;212;01m0[39;00m[38;5;87m][39m[38;5;87m.[39m[38;5;230mmainNode[39m[38;5;230m[0m
+[15:03:48]: ▸ [35m[38;5;230m            [39m[38;5;230mdocumentController[39m[38;5;87m.[39m[38;5;230mcanvasController[39m[38;5;87m.[39m[38;5;153mrewireNodes[39m[38;5;87m([39m[38;5;230mmainNode[39m[38;5;87m.[39m[38;5;230msubnodes[39m[38;5;230m [39m[38;5;221;01mas[39;00m[38;5;230m [39m[38;5;155;01mNSArray[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mto[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mnil[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mwantNewLocation[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mtrue[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mcanInheritStyle[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mfalse[39;00m[38;5;87m)[39m[38;5;230m[0m
+[15:03:48]: ▸ [35m[38;5;230m            [39m[38;5;230mdocumentController[39m[38;5;87m.[39m[38;5;230mcanvasController[39m[38;5;87m.[39m[38;5;153mremoveNodeAndAllSubnodes[39m[38;5;87m([39m[38;5;230mmainNode[39m[38;5;87m)[39m[38;5;230m[0m
+[15:03:48]: ▸ [35m[38;5;230m[39m  ```[0m
+[15:03:48]: ▸ [35m[31m	 Executed 462 tests, with 1 failure (1 unexpected) in 124.772 (125.029) seconds[0m
+[15:03:48]: ▸ [35m[0m
+[15:03:49]: ▸ [35m[39;1mSelected tests[0m
+[15:03:49]: ▸ [35mTest Suite [39;1mPurchasing Tests macOS.xctest[0m started[0m
+[15:03:49]: ▸ [35m[39;1mCurrentReceiptParsingTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testiOSReceiptValidation ([31m0.307[0m seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMacOSReceiptValidation (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mLicenseValidatorTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testBrokenLicenseData (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testBrokenSignedLicenseData (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testEmtpyData (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMissingData (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testParsingSignedLicense1 (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSignedLicense (0.010 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSignedLicenseWithTrial (0.003 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicense (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSignedProductionLicenseWithTrial (0.003 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSkippingCertificate (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testValidatingSkippingDeviceIdentifier (0.003 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testWrongCertificate (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifier (0.008 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testWrongDeviceIdentifierAndCertificate (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mPromotedVisibilityUpdaterTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testCatalogNeeded (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testDoubleUpdateProtection (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testInitialVisibilityUpdates (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testOverriddenUpdating (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testVisibiliesForFullVersion (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testVisibiliesFromTrial (0.003 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testVisibilitiesForPendingDecision (0.003 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mPurchaseServiceDataStoreTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testPersistence (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testUpdateMethods (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mPurchaseServiceTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testActiveTrialLicenseTrumpsViewerOnly (0.011 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testAdditionalAvailableDiscountedProductOverrulesReceipt (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testFromExpiredIAPTrialToViewerOnly (0.008 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testFromIAPTrialToViewerOnly (0.005 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testFullPurchase (0.007 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testFullPurchaseFromTrialLicense (0.007 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testIAPTrialExpiry (0.019 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testIAPTrialVsLongerTrialLicense (0.005 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testIAPTrialVsShorterTrialLicense (0.005 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testLicenseTrialExpiry (0.023 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithExistingLicense (0.009 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInitializationWithoutExistingLicense (0.006 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testPurchaseServiceInvalidReceiptData (0.005 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testReceiptOverrulesAdditionalAvailableDiscountedProduct (0.005 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testStartingTrial (0.007 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testViewerOnlyThenTrialLicenseThenViewerOnly (0.009 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mSignatureVerifierTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testCorrectSignatures (0.004 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMalformedData (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMalformedSignatureData (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMlformedCertificateData (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[33m◷[0m testPerformanceOfSignatureVerification measured (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testPerformanceOfSignatureVerification ([31m0.306[0m seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testWrongSignatures (0.007 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mUpgradePathAnalysisTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testConcreteiOSUpgradePathAnalysis (0.008 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testConcreteMacOSUpgradePathAnalysis (0.002 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testiOSLegacyReceiptParsing (0.007 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testMacOSLegacyReceiptParsing (0.004 seconds)[0m
+[15:03:49]: ▸ [35m[39;1mVersionNumberTests[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testDigitsAndDotsComparison (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testDigitsAndDotsParsing (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testDigitsOnly (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m✓[0m testDigitsOnlyParsing (0.001 seconds)[0m
+[15:03:49]: ▸ [35m[32;1m	 Executed 55 tests, with 0 failures (0 unexpected) in 0.869 (0.899) seconds[0m
+[15:03:49]: ▸ [35m[0m
+[15:03:50]: ▸ [35m** TEST FAILED **[0m
+[33m▸[0m [39;1mAnalyzing[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m ZIPFoundation_Info.plist
+[33m▸[0m [39;1mCompiling[0m Archive+Reading.swift
+[33m▸[0m [39;1mCompiling[0m Archive+Writing.swift
+[33m▸[0m [39;1mCompiling[0m Archive.swift
+[33m▸[0m [39;1mCompiling[0m Data+Compression.swift
+[33m▸[0m [39;1mCompiling[0m Data+Serialization.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/ZIPFoundation/Sources/ZIPFoundation/Data+Serialization.swift:60:45: [33m'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'[0m
+
+let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+[36m                                            ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Entry.swift
+[33m▸[0m [39;1mCompiling[0m FileManager+ZIP.swift
+[33m▸[0m [39;1mLinking[0m ZIPFoundation
+[33m▸[0m [39;1mTouching[0m ZIPFoundation.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/MNCLogging-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m MNCLogging-macOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m MNCLogging.m
+[33m▸[0m [39;1mCompiling[0m MNCLogLevel.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging-macOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogging.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLogLevel.m
+[33m▸[0m [39;1mBuilding library[0m libMNCLogging-macOS.a
+[33m▸[0m [39;1mAnalyzing[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Ashton_Info.plist
+[33m▸[0m [39;1mCompiling[0m Mappings.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLReader.swift
+[33m▸[0m [39;1mCompiling[0m AshtonXMLParser.swift
+[33m▸[0m [39;1mCompiling[0m FontBuilder.swift
+[33m▸[0m [39;1mCompiling[0m AshtonHTMLWriter.swift
+[33m▸[0m [39;1mCompiling[0m Iterator+Parsing.swift
+[33m▸[0m [39;1mCompiling[0m CrossPlatformCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m Ashton.swift
+[33m▸[0m [39;1mCompiling[0m Ashton_vers.c
+[33m▸[0m [39;1mLinking[0m Ashton
+[33m▸[0m [39;1mCopying[0m Ashton.h
+[33m▸[0m [39;1mTouching[0m Ashton.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/cmark-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m blocks.c
+[33m▸[0m [39;1mCompiling[0m buffer.c
+[33m▸[0m [39;1mCompiling[0m cmark-macOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m cmark.c
+[33m▸[0m [39;1mCompiling[0m cmark_ctype.c
+[33m▸[0m [39;1mCompiling[0m commonmark.c
+[33m▸[0m [39;1mCompiling[0m houdini_href_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_e.c
+[33m▸[0m [39;1mCompiling[0m houdini_html_u.c
+[33m▸[0m [39;1mCompiling[0m html.c
+[33m▸[0m [39;1mCompiling[0m inlines.c
+[33m▸[0m [39;1mCompiling[0m iterator.c
+[33m▸[0m [39;1mCompiling[0m latex.c
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m man.c
+[33m▸[0m [39;1mCompiling[0m node.c
+[33m▸[0m [39;1mCompiling[0m references.c
+[33m▸[0m [39;1mCompiling[0m render.c
+[33m▸[0m [39;1mCompiling[0m scanners.c
+[33m▸[0m [39;1mCompiling[0m utf8.c
+[33m▸[0m [39;1mCompiling[0m xml.c
+[33m▸[0m [39;1mAnalyzing[0m blocks.c
+[33m▸[0m [39;1mAnalyzing[0m buffer.c
+[33m▸[0m [39;1mAnalyzing[0m cmark-macOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m cmark.c
+[33m▸[0m [39;1mAnalyzing[0m cmark_ctype.c
+[33m▸[0m [39;1mAnalyzing[0m commonmark.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_href_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_e.c
+[33m▸[0m [39;1mAnalyzing[0m houdini_html_u.c
+[33m▸[0m [39;1mAnalyzing[0m html.c
+[33m▸[0m [39;1mAnalyzing[0m inlines.c
+[33m▸[0m [39;1mAnalyzing[0m iterator.c
+[33m▸[0m [39;1mAnalyzing[0m latex.c
+[33m▸[0m [39;1mAnalyzing[0m main.c
+[33m▸[0m [39;1mAnalyzing[0m man.c
+[33m▸[0m [39;1mAnalyzing[0m node.c
+[33m▸[0m [39;1mAnalyzing[0m references.c
+[33m▸[0m [39;1mAnalyzing[0m render.c
+[33m▸[0m [39;1mAnalyzing[0m scanners.c
+[33m▸[0m [39;1mAnalyzing[0m utf8.c
+[33m▸[0m [39;1mAnalyzing[0m xml.c
+[33m▸[0m [39;1mBuilding library[0m libcmark-macOS.a
+[33m▸[0m [39;1mAnalyzing[0m Pods/CHCSVParser-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser-macOS-dummy.m
+[33m▸[0m [39;1mCompiling[0m CHCSVParser.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser-macOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m CHCSVParser.m
+[33m▸[0m [39;1mBuilding library[0m libCHCSVParser-macOS.a
+[33m▸[0m [39;1mAnalyzing[0m AppReceiptValidator/AppReceiptValidator macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info-macOS.plist
+[33m▸[0m [39;1mCompiling[0m UnofficialReceipt.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator.swift
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator+Parameters.swift
+[33m▸[0m [39;1mCompiling[0m DeviceIdentifier+installedDeviceIdentifier_macOS.swift
+[33m▸[0m [39;1mCompiling[0m Receipt.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m KnownOrUnknown.swift
+[33m▸[0m [39;1mCompiling[0m ASN1Helpers.swift
+[33m▸[0m [39;1mCompiling[0m OpenSSLWrappers.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mCompiling[0m AppReceiptValidator_vers.c
+[33m▸[0m [39;1mAnalyzing[0m pkcs7_union_accessors.c
+[33m▸[0m [39;1mLinking[0m AppReceiptValidator
+[33m▸[0m [39;1mCopying[0m ssl3.h
+[33m▸[0m [39;1mCopying[0m pem2.h
+[33m▸[0m [39;1mCopying[0m mdc2.h
+[33m▸[0m [39;1mCopying[0m stack.h
+[33m▸[0m [39;1mCopying[0m err.h
+[33m▸[0m [39;1mCopying[0m pkcs7.h
+[33m▸[0m [39;1mCopying[0m asn1t.h
+[33m▸[0m [39;1mCopying[0m ui.h
+[33m▸[0m [39;1mCopying[0m asn1.h
+[33m▸[0m [39;1mCopying[0m buffer.h
+[33m▸[0m [39;1mCopying[0m x509.h
+[33m▸[0m [39;1mCopying[0m opensslv.h
+[33m▸[0m [39;1mCopying[0m crypto.h
+[33m▸[0m [39;1mCopying[0m kssl.h
+[33m▸[0m [39;1mCopying[0m cast.h
+[33m▸[0m [39;1mCopying[0m ssl.h
+[33m▸[0m [39;1mCopying[0m bn.h
+[33m▸[0m [39;1mCopying[0m rc4.h
+[33m▸[0m [39;1mCopying[0m tls1.h
+[33m▸[0m [39;1mCopying[0m camellia.h
+[33m▸[0m [39;1mCopying[0m rand.h
+[33m▸[0m [39;1mCopying[0m des_old.h
+[33m▸[0m [39;1mCopying[0m x509_vfy.h
+[33m▸[0m [39;1mCopying[0m pkcs12.h
+[33m▸[0m [39;1mCopying[0m evp.h
+[33m▸[0m [39;1mCopying[0m engine.h
+[33m▸[0m [39;1mCopying[0m ssl23.h
+[33m▸[0m [39;1mCopying[0m modes.h
+[33m▸[0m [39;1mCopying[0m idea.h
+[33m▸[0m [39;1mCopying[0m x509v3.h
+[33m▸[0m [39;1mCopying[0m blowfish.h
+[33m▸[0m [39;1mCopying[0m aes.h
+[33m▸[0m [39;1mCopying[0m cmac.h
+[33m▸[0m [39;1mCopying[0m txt_db.h
+[33m▸[0m [39;1mCopying[0m dso.h
+[33m▸[0m [39;1mCopying[0m pkcs7_union_accessors.h
+[33m▸[0m [39;1mCopying[0m objects.h
+[33m▸[0m [39;1mCopying[0m dtls1.h
+[33m▸[0m [39;1mCopying[0m cms.h
+[33m▸[0m [39;1mCopying[0m dsa.h
+[33m▸[0m [39;1mCopying[0m ssl2.h
+[33m▸[0m [39;1mCopying[0m ripemd.h
+[33m▸[0m [39;1mCopying[0m ts.h
+[33m▸[0m [39;1mCopying[0m conf.h
+[33m▸[0m [39;1mCopying[0m lhash.h
+[33m▸[0m [39;1mCopying[0m obj_mac.h
+[33m▸[0m [39;1mCopying[0m ui_compat.h
+[33m▸[0m [39;1mCopying[0m rsa.h
+[33m▸[0m [39;1mCopying[0m ec.h
+[33m▸[0m [39;1mCopying[0m ecdsa.h
+[33m▸[0m [39;1mCopying[0m hmac.h
+[33m▸[0m [39;1mCopying[0m seed.h
+[33m▸[0m [39;1mCopying[0m whrlpool.h
+[33m▸[0m [39;1mCopying[0m bio.h
+[33m▸[0m [39;1mCopying[0m ebcdic.h
+[33m▸[0m [39;1mCopying[0m dh.h
+[33m▸[0m [39;1mCopying[0m asn1_mac.h
+[33m▸[0m [39;1mCopying[0m des.h
+[33m▸[0m [39;1mCopying[0m krb5_asn.h
+[33m▸[0m [39;1mCopying[0m pqueue.h
+[33m▸[0m [39;1mCopying[0m rc2.h
+[33m▸[0m [39;1mCopying[0m ossl_typ.h
+[33m▸[0m [39;1mCopying[0m srtp.h
+[33m▸[0m [39;1mCopying[0m srp.h
+[33m▸[0m [39;1mCopying[0m e_os2.h
+[33m▸[0m [39;1mCopying[0m opensslconf.h
+[33m▸[0m [39;1mCopying[0m md4.h
+[33m▸[0m [39;1mCopying[0m ecdh.h
+[33m▸[0m [39;1mCopying[0m comp.h
+[33m▸[0m [39;1mCopying[0m safestack.h
+[33m▸[0m [39;1mCopying[0m symhacks.h
+[33m▸[0m [39;1mCopying[0m conf_api.h
+[33m▸[0m [39;1mCopying[0m ocsp.h
+[33m▸[0m [39;1mCopying[0m sha.h
+[33m▸[0m [39;1mCopying[0m pem.h
+[33m▸[0m [39;1mCopying[0m md5.h
+[33m▸[0m [39;1mCopying[0m AppReceiptValidator/AppleIncRootCertificate.cer
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mTouching[0m AppReceiptValidator.framework
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/CommonCrypto macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CommonCrypto_vers.c
+[33m▸[0m [39;1mLinking[0m CommonCrypto
+[33m▸[0m [39;1mCopying[0m CommonCrypto_macOS.h
+[33m▸[0m [39;1mTouching[0m CommonCrypto.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/box2d-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2Body.cpp
+[33m▸[0m [39;1mCompiling[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ChainShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2CircleShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mCompiling[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mCompiling[0m b2Collision.cpp
+[33m▸[0m [39;1mCompiling[0m b2Contact.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactManager.cpp
+[33m▸[0m [39;1mCompiling[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mCompiling[0m b2Distance.cpp
+[33m▸[0m [39;1mCompiling[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Draw.cpp
+[33m▸[0m [39;1mCompiling[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2Fixture.cpp
+[33m▸[0m [39;1mCompiling[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2GearJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Island.cpp
+[33m▸[0m [39;1mCompiling[0m b2Joint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Math.cpp
+[33m▸[0m [39;1mCompiling[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mCompiling[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mCompiling[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Rope.cpp
+[33m▸[0m [39;1mCompiling[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2Settings.cpp
+[33m▸[0m [39;1mCompiling[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mCompiling[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mCompiling[0m b2Timer.cpp
+[33m▸[0m [39;1mCompiling[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mCompiling[0m b2World.cpp
+[33m▸[0m [39;1mCompiling[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mCompiling[0m box2d-macOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m b2BlockAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Body.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2BroadPhase.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ChainShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CircleShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideCircle.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollideEdge.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2CollidePolygon.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Collision.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Contact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactManager.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2ContactSolver.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Distance.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DistanceJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Draw.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2DynamicTree.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeAndPolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2EdgeShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Fixture.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2FrictionJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2GearJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Island.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Joint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Math.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MotorJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2MouseJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonAndCircleContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonContact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PolygonShape.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PrismaticJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2PulleyJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RevoluteJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Rope.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2RopeJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Settings.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2StackAllocator.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2TimeOfImpact.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2Timer.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WeldJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WheelJoint.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2World.cpp
+[33m▸[0m [39;1mAnalyzing[0m b2WorldCallbacks.cpp
+[33m▸[0m [39;1mAnalyzing[0m box2d-macOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libbox2d-macOS.a
+[33m▸[0m [39;1mAnalyzing[0m Shared/Shared macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Shared-macOS-Info.plist
+[33m▸[0m [39;1mCompiling[0m Platform.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Shared/Shared/Platform.swift:23:46: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#elseif (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                                            ^~~~~~~~ ~~~~~        ~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m ErrorComparison.swift
+[33m▸[0m [39;1mCompiling[0m Observable.swift
+[33m▸[0m [39;1mCompiling[0m Result.swift
+[33m▸[0m [39;1mCompiling[0m Numbers.swift
+[33m▸[0m [39;1mCompiling[0m Collection+BackwardCompatibility.swift
+[33m▸[0m [39;1mCompiling[0m DefaultsItem.swift
+[33m▸[0m [39;1mCompiling[0m Sequence+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m NetworkDebugging.swift
+[33m▸[0m [39;1mCompiling[0m SupportLink.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction+Cocoa.swift
+[33m▸[0m [39;1mCompiling[0m Dictionary+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Comparable+Clamped.swift
+[33m▸[0m [39;1mCompiling[0m NotificationObserver.swift
+[33m▸[0m [39;1mCompiling[0m HierarchicalError.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedNSError.swift
+[33m▸[0m [39;1mCompiling[0m MessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo.swift
+[33m▸[0m [39;1mCompiling[0m WeakRef.swift
+[33m▸[0m [39;1mCompiling[0m URL+Sugar.swift
+[33m▸[0m [39;1mCompiling[0m DebugAction.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedError+suggestedErrorDetails.swift
+[33m▸[0m [39;1mCompiling[0m Selector+Mirror.swift
+[33m▸[0m [39;1mCompiling[0m Defaults.swift
+[33m▸[0m [39;1mCompiling[0m LocalizedErrorViaMessageConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m MNCDebugInfo.swift
+[33m▸[0m [39;1mCompiling[0m DebugMenu.swift
+[33m▸[0m [39;1mCompiling[0m MNCEnumInitializer.swift
+[33m▸[0m [39;1mCompiling[0m AppContextInfo+UserAgent.swift
+[33m▸[0m [39;1mCompiling[0m UserDebugging+macOS.swift
+[33m▸[0m [39;1mCompiling[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m MNCWeakArray.m
+[33m▸[0m [39;1mCompiling[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCMirror.m
+[33m▸[0m [39;1mCompiling[0m Shared_vers.c
+[33m▸[0m [39;1mAnalyzing[0m NSArray+MNFunctional.m
+[33m▸[0m [39;1mAnalyzing[0m MNCWeakArray.m
+[33m▸[0m [39;1mAnalyzing[0m NSSet+MNFunctional.m
+[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m NSNumber+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMirror.m
+[33m▸[0m [39;1mLinking[0m Shared
+[33m▸[0m [39;1mCopying[0m NSNumber+Convenience.h
+[33m▸[0m [39;1mCopying[0m MNCWeakArray.h
+[33m▸[0m [39;1mCopying[0m NSSet+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNCMirror.h
+[33m▸[0m [39;1mCopying[0m SystemFrameworkLocalizer.h
+[33m▸[0m [39;1mCopying[0m NSArray+MNFunctional.h
+[33m▸[0m [39;1mCopying[0m MNFunctions.h
+[33m▸[0m [39;1mTouching[0m Shared.framework
+[33m▸[0m [39;1mAnalyzing[0m Reachability/ReachabilityMac [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m Reachability.swift
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Carthage/Checkouts/Reachability.swift/Reachability/Reachability.swift:136:42: [33mplaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead[0m
+
+#if (arch(i386) || arch(x86_64)) && os(iOS)
+[36m                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mCompiling[0m Reachability_vers.c
+[33m▸[0m [39;1mLinking[0m Reachability
+[33m▸[0m [39;1mCopying[0m ReachabilityMac.h
+[33m▸[0m [39;1mTouching[0m Reachability.framework
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m MindNodeQuickLookPlugIn-Info.plist
+[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeQuickLookPlugIn/MindNodeQuickLookPlugIn-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m GenerateThumbnailForURL.m
+[33m▸[0m [39;1mCompiling[0m GeneratePreviewForURL.m
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m SSWZip.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mAnalyzing[0m GenerateThumbnailForURL.m
+[33m▸[0m [39;1mAnalyzing[0m GeneratePreviewForURL.m
+[33m▸[0m [39;1mAnalyzing[0m main.c
+[33m▸[0m [39;1mAnalyzing[0m SSWZip.m
+[33m▸[0m [39;1mLinking[0m MindNodeQuickLookPlugIn
+[33m▸[0m [39;1mCopying[0m InfoPlist.strings
+[33m▸[0m [39;1mTouching[0m MindNodeQuickLookPlugIn.qlgenerator
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNodeSpotlightImporter [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m MindNodeSpotlightImporter-Info.plist
+[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m MindNodeSpotlightImporter/MindNodeSpotlightImporter-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m main.c
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m SSWZip.m
+[33m▸[0m [39;1mCompiling[0m GetMetadataForFile.m
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mAnalyzing[0m main.c
+[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mAnalyzing[0m SSWZip.m
+[33m▸[0m [39;1mAnalyzing[0m GetMetadataForFile.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mLinking[0m MindNodeSpotlightImporter
+[33m▸[0m [39;1mCopying[0m MindNodeSpotlightImporter/schema.xml
+[33m▸[0m [39;1mCopying[0m InfoPlist.strings
+[33m▸[0m [39;1mTouching[0m MindNodeSpotlightImporter.mdimporter
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode Helper [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m main.m
+[33m▸[0m [39;1mCompiling[0m AppDelegate.m
+[33m▸[0m [39;1mAnalyzing[0m main.m
+[33m▸[0m [39;1mAnalyzing[0m AppDelegate.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCompiling[0m MainMenu.xib
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mTouching[0m MindNode\ Helper.app
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for macOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ macOS\ Tests-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ macOS\ Tests-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ macOS\ Tests.a
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode Quick Entry [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCopying[0m Resources/Colors
+[33m▸[0m [39;1mCompiling[0m MNXQuickEntryPopoverViewController.xib
+[33m▸[0m [39;1mCompiling[0m MainMenu.xib
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework
+[33m▸[0m [39;1mTouching[0m MindNode\ Quick\ Entry.app
+[33m▸[0m [39;1mAnalyzing[0m Purchasing/Purchasing macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCompiling[0m CancellableTimeout.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+State.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceStateDemoData.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdater.swift
+[33m▸[0m [39;1mCompiling[0m AppModeScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m TimeMeasurement.swift
+[33m▸[0m [39;1mCompiling[0m SignedLicense.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefresher.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m ProductFetchRequest.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysis.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptRefreshingState.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater.swift
+[33m▸[0m [39;1mCompiling[0m State+AllowedDecisions.swift
+[33m▸[0m [39;1mCompiling[0m JSONCoding+DefaultConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductCatalogState.swift
+[33m▸[0m [39;1mCompiling[0m License.swift
+[33m▸[0m [39;1mCompiling[0m License+Products.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.swift
+[33m▸[0m [39;1mCompiling[0m LicenseRepository.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.swift
+[33m▸[0m [39;1mCompiling[0m ButtonConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m StorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+Error.swift
+[33m▸[0m [39;1mCompiling[0m StoreKitWrapper.swift
+[33m▸[0m [39;1mCompiling[0m PaymentQueueState.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStore.swift
+[33m▸[0m [39;1mCompiling[0m AppStoreProductDemoData.swift
+[33m▸[0m [39;1mCompiling[0m State+ChangeObservations.swift
+[33m▸[0m [39;1mCompiling[0m PersistedInfo.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidator.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService.swift
+[33m▸[0m [39;1mCompiling[0m ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentState.swift
+[33m▸[0m [39;1mCompiling[0m ProductViewModel.swift
+[33m▸[0m [39;1mCompiling[0m PromotedPaymentHandler.swift
+[33m▸[0m [39;1mCompiling[0m TrialState.swift
+[33m▸[0m [39;1mCompiling[0m StateChange+DeferredPaymentMessage.swift
+[33m▸[0m [39;1mCompiling[0m UnifiedPurchaseScreenViewModel.swift
+[33m▸[0m [39;1mCompiling[0m Then.swift
+[33m▸[0m [39;1mCompiling[0m VersionNumber.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration+Debugging.swift
+[33m▸[0m [39;1mCompiling[0m SupportInfoConvertible.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+ProductIdentifiers.swift
+[33m▸[0m [39;1mCompiling[0m CurrentProductState.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifier.swift
+[33m▸[0m [39;1mCompiling[0m DefaultPurchaseServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m LicenseUpdater+Error.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseService+DebugActions.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptDemoData.swift
+[33m▸[0m [39;1mCompiling[0m AutoStaticMembersListable.generated.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseSupportInfoGatherer.swift
+[33m▸[0m [39;1mCompiling[0m DeviceCheckTokenProviderProtocol.swift
+[33m▸[0m [39;1mCompiling[0m AutoEquatable.generated.swift
+[33m▸[0m [39;1mCompiling[0m Purchasing_vers.c
+[33m▸[0m [39;1mLinking[0m Purchasing
+[33m▸[0m [39;1mCopying[0m Purchasing_macOS.h
+[33m▸[0m [39;1mTouching[0m Purchasing.framework
+[33m▸[0m [39;1mAnalyzing[0m Pods/Pods-MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m Pods-MindNode\ for\ macOS-dummy.m
+[33m▸[0m [39;1mAnalyzing[0m Pods-MindNode\ for\ macOS-dummy.m
+[33m▸[0m [39;1mBuilding library[0m libPods-MindNode\ for\ macOS.a
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Purchasing/Purchasing/Service/PurchaseService.swift:542:9: [33mIdentifier Name Violation: Variable name should be between 3 and 40 characters long: 'upgradePathFromAdditionalDiscountedProduct' (identifier_name)[0m
+
+Linting 'DataStoreTestContext.swift' (369/601)
+[36m            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch
+[33m▸[0m [39;1mPrecompiling[0m macOS-Prefix.pch
+[33m▸[0m [39;1mCompiling[0m MNCPDFExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController.m
+[33m▸[0m [39;1mCompiling[0m MNXInspectorClipView.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+ObjectsConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNCNode+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNXNumberFormatter.m
+[33m▸[0m [39;1mCompiling[0m NSDateFormatter+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeView.m
+[33m▸[0m [39;1mCompiling[0m MNXMindNodeSingleFileExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme.m
+[33m▸[0m [39;1mCompiling[0m MNXKeyCommand.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Components.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineBaseCellView.m
+[33m▸[0m [39;1mCompiling[0m NSView+LayoutConstraintFiltering.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection.m
+[33m▸[0m [39;1mCompiling[0m MNCFileLink.m
+[33m▸[0m [39;1mCompiling[0m NSWindow+FullScreen.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXTextAlignmentValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m MNCHoverNodeState.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionView.m
+[33m▸[0m [39;1mCompiling[0m MNCPastePersistentManager.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRenderer.m
+[33m▸[0m [39;1mCompiling[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mCompiling[0m NSIndexPath+MNCollectionView.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutControllerManager.mm
+[33m▸[0m [39;1mCompiling[0m NSString+UUID.m
+[33m▸[0m [39;1mCompiling[0m MNCNode.m
+[33m▸[0m [39;1mCompiling[0m MNDefaults.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+Stack.m
+[33m▸[0m [39;1mCompiling[0m MNCShapeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeView.m
+[33m▸[0m [39;1mCompiling[0m NSMutableArray+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNXClipView.m
+[33m▸[0m [39;1mCompiling[0m MNCColorValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxy.m
+[33m▸[0m [39;1mCompiling[0m MNCTranslateNodeController.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineRowView.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnection+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXTranslateNodeKnobState.m
+[33m▸[0m [39;1mCompiling[0m MNXDocument.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadDocumentViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXOpenBrowserSharingService.m
+[33m▸[0m [39;1mCompiling[0m MNXColorWell+Bindings.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelectionController.m
+[33m▸[0m [39;1mCompiling[0m MNXShadowSeparatorContentView.m
+[33m▸[0m [39;1mCompiling[0m MNCMarkdownExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindParser.m
+[33m▸[0m [39;1mCompiling[0m MNXNoteIndicatorButton.m
+[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedControl.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCNote.m
+[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXNodePopoverManager.m
+[33m▸[0m [39;1mCompiling[0m NSDictionary+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNXFontManager.m
+[33m▸[0m [39;1mCompiling[0m MNXImageBrowserItem.m
+[33m▸[0m [39;1mCompiling[0m NSPopover+MNDetach.m
+[33m▸[0m [39;1mCompiling[0m MNCImageExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXDocument+Scripting.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNode.m
+[33m▸[0m [39;1mCompiling[0m MNCPathView.m
+[33m▸[0m [39;1mCompiling[0m NSImage+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineLayouter.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNXSheetWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNXColorWell.m
+[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedControl.m
+[33m▸[0m [39;1mCompiling[0m MNColor+CIELAB.m
+[33m▸[0m [39;1mCompiling[0m MNXPageSliderCell.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController+box2dInterface.mm
+[33m▸[0m [39;1mCompiling[0m MNCContent.m
+[33m▸[0m [39;1mCompiling[0m NSView+Alignment.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleController.m
+[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleValue.m
+[33m▸[0m [39;1mCompiling[0m MNTextView+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCText+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m NSSegmentedControl+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m NSFontDescriptor+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCFontStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerComposedDataSource.m
+[33m▸[0m [39;1mCompiling[0m NSUserDefaults+MNCProperties.m
+[33m▸[0m [39;1mCompiling[0m MNCAsset.m
+[33m▸[0m [39;1mCompiling[0m MNFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNCDevice.m
+[33m▸[0m [39;1mCompiling[0m MNMainThreadHangDetector.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeInteractionState.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNCPathStyle.m
+[33m▸[0m [39;1mCompiling[0m MNVector.m
+[33m▸[0m [39;1mCompiling[0m MNXVibrantButtonCell.m
+[33m▸[0m [39;1mCompiling[0m MNXAppDelegate.m
+[33m▸[0m [39;1mCompiling[0m MNXDraggingOperationState.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseParser.m
+[33m▸[0m [39;1mCompiling[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mCompiling[0m MNCMigrationManager.m
+[33m▸[0m [39;1mCompiling[0m MNXLayoutManager.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeEditAccountWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNXQuickLookController.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNCConvexHullController.mm
+[33m▸[0m [39;1mCompiling[0m NSTextAttachment+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVParser.m
+[33m▸[0m [39;1mCompiling[0m MNCIThoughtsParser.m
+[33m▸[0m [39;1mCompiling[0m MNXTranslateCrossConnectionKnobState.m
+[33m▸[0m [39;1mCompiling[0m NSURL+QueryParsing.m
+[33m▸[0m [39;1mCompiling[0m MNCFreeMindExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.m
+[33m▸[0m [39;1mCompiling[0m NSView+Insertion.m
+[33m▸[0m [39;1mCompiling[0m MNCPlainTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxyController.m
+[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineDefines.m
+[33m▸[0m [39;1mCompiling[0m MNCRichTextExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m
+[33m▸[0m [39;1mCompiling[0m MNXSidebarContainer.m
+[33m▸[0m [39;1mCompiling[0m MNCMindjetParser.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBaseDataSource.m
+[33m▸[0m [39;1mCompiling[0m NSParagraphStyle+MNConvenience.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNXSwitch.m
+[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCUserGuideView.m
+[33m▸[0m [39;1mCompiling[0m MNCImageAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNCArrowStyle.m
+[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXSingleAxisScrollView.m
+[33m▸[0m [39;1mCompiling[0m NSData+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskSyncController.m
+[33m▸[0m [39;1mCompiling[0m MNCValueTransformerRegistration.m
+[33m▸[0m [39;1mCompiling[0m MNCExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXAttachableButtonCell.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineTasksDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m
+[33m▸[0m [39;1mCompiling[0m NSApplication+LaunchServices.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme+Creation.m
+[33m▸[0m [39;1mCompiling[0m MNXImageView.m
+[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCloudShapeGenerator.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineSearchDataSource.m
+[33m▸[0m [39;1mCompiling[0m MNCText.m
+[33m▸[0m [39;1mCompiling[0m NSEvent+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCTask.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeAccessoryButton.m
+[33m▸[0m [39;1mCompiling[0m NSCursor+ObjectManipulationCursors.m
+[33m▸[0m [39;1mCompiling[0m MNXInspectorSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOPMLParser.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineNodeCache.m
+[33m▸[0m [39;1mCompiling[0m NSMutableAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m NSPasteboard+Additions.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXCanvasInteractionState.m
+[33m▸[0m [39;1mCompiling[0m NSBezierPath+MNCGPathRef.m
+[33m▸[0m [39;1mCompiling[0m CAAnimation+MNCompletionBlocks.m
+[33m▸[0m [39;1mCompiling[0m MNXPreferencesView.m
+[33m▸[0m [39;1mCompiling[0m MNXFoldingIndicatorButton.m
+[33m▸[0m [39;1mCompiling[0m MNXThingsAppleScriptExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas+MNPropertyRepresentation.m
+[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCAttachmentRenderer.m
+[33m▸[0m [39;1mCompiling[0m NSValue+MNPlatformCompatibility.m
+[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXColorSwatchView.m
+[33m▸[0m [39;1mCompiling[0m MNCImagePickerContentDataSource.m
+[33m▸[0m [39;1mCompiling[0m NSSharingService+MNXAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNXSanitizingTextView.m
+[33m▸[0m [39;1mCompiling[0m MNCBranchRepresentedObject.m
+[33m▸[0m [39;1mCompiling[0m MNCSubselectionResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNImporting.m
+[33m▸[0m [39;1mCompiling[0m MNXCanvasView.m
+[33m▸[0m [39;1mCompiling[0m MNCAnalyticsTracker.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadCompleteViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXColorGridView.m
+[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarContainerView.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNXDemoOverlayView.m
+[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXMyMindNodePreferencesViewController.m
+[33m▸[0m [39;1mCompiling[0m NSString+Paths.m
+[33m▸[0m [39;1mCompiling[0m MNError.m
+[33m▸[0m [39;1mCompiling[0m MNCLayoutManager.m
+[33m▸[0m [39;1mCompiling[0m MNCTheme1To2MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument4to5MigrationController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvas.m
+[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXExportSheetToolbarButtonContainerView.m
+[33m▸[0m [39;1mCompiling[0m MNCDocument+MNExporting.m
+[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXRubberBandView.m
+[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineTableView.m
+[33m▸[0m [39;1mCompiling[0m MNXCanvasPrintView.m
+[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasRenderer.m
+[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersSharingService.m
+[33m▸[0m [39;1mCompiling[0m MNCAshtonValueTransformer.m
+[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareLinkViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCRemindersExporter.m
+[33m▸[0m [39;1mCompiling[0m NSScrollView+ScrollingAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNXTaskButton.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArtAttachment.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasController.m
+[33m▸[0m [39;1mCompiling[0m NSURL+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCTextOutlineParser.m
+[33m▸[0m [39;1mCompiling[0m MNXTextFinderClient.m
+[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCStrokeStyle.m
+[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCClipArt.m
+[33m▸[0m [39;1mCompiling[0m NSFont+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.m
+[33m▸[0m [39;1mCompiling[0m MNCMyMindNodeDocument.m
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNZooming.m
+[33m▸[0m [39;1mCompiling[0m MNCCollisionController.mm
+[33m▸[0m [39;1mCompiling[0m MNCClipArtSet.m
+[33m▸[0m [39;1mCompiling[0m MNCNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNXFunctions.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineCellView.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCCSVExporter.m
+[33m▸[0m [39;1mCompiling[0m MNCBaseStyle.m
+[33m▸[0m [39;1mCompiling[0m MNXOutlineSearchCellView.m
+[33m▸[0m [39;1mCompiling[0m MNCKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNCTaskButton.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentObjectSavingManager.m
+[33m▸[0m [39;1mCompiling[0m MNXCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNXVibrantSquareSegmentedCell.m
+[33m▸[0m [39;1mCompiling[0m NSView+Animation.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+NodeActions.m
+[33m▸[0m [39;1mCompiling[0m MNCCrossConnectionStyle.m
+[33m▸[0m [39;1mCompiling[0m MNXScrollView.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m
+[33m▸[0m [39;1mCompiling[0m MNXCreateNodeInteractionState.m
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegisterWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNXAttachedTextField.m
+[33m▸[0m [39;1mCompiling[0m MNXExportViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCTextController.m
+[33m▸[0m [39;1mCompiling[0m MNXSearchField.m
+[33m▸[0m [39;1mCompiling[0m MNCPersistentImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNXInteractionState.m
+[33m▸[0m [39;1mCompiling[0m MNXDemoLaunchWindowController.m
+[33m▸[0m [39;1mCompiling[0m MNXImageBrowserCell.m
+[33m▸[0m [39;1mCompiling[0m SSWZip.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasSelection.m
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNViewActions.m
+[33m▸[0m [39;1mCompiling[0m MNCDocumentKVOController+Selection.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNSwizzling.m
+[33m▸[0m [39;1mCompiling[0m MNXCreateCrossConnectionState.m
+[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.m
+[33m▸[0m [39;1mCompiling[0m NSAttributedString+Convenience.m
+[33m▸[0m [39;1mCompiling[0m MNCSimpleXMLExporter.m
+[33m▸[0m [39;1mCompiling[0m MNXDragAndDropImageView.m
+[33m▸[0m [39;1mCompiling[0m MNCMindNodeExporter.m
+[33m▸[0m [39;1mCompiling[0m NSGraphicsContext+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCPasteboardController.m
+[33m▸[0m [39;1mCompiling[0m MNXResizableScrollView.m
+[33m▸[0m [39;1mCompiling[0m MNXColoredSegmentedCell.m
+[33m▸[0m [39;1mCompiling[0m NSObject+MNCoalescing.m
+[33m▸[0m [39;1mCompiling[0m MNXTextView.m
+[33m▸[0m [39;1mCompiling[0m MNXImageBrowserView.m
+[33m▸[0m [39;1mCompiling[0m MNCCachingImageManager.m
+[33m▸[0m [39;1mCompiling[0m MNXNodeWellButton.m
+[33m▸[0m [39;1mCompiling[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mCompiling[0m MNCUndoManager.m
+[33m▸[0m [39;1mCompiling[0m MNXTextEditor.m
+[33m▸[0m [39;1mCompiling[0m MTDXMLElement.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchToggleButton.m
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCycleNode.m
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m
+[33m▸[0m [39;1mCompiling[0m main.m
+[33m▸[0m [39;1mCompiling[0m MNCCanvasViewController.m
+[33m▸[0m [39;1mCompiling[0m MNCOutlineBranchColorView.m
+[33m▸[0m [39;1mCompiling[0m MNXView.m
+[33m▸[0m [39;1mCompiling[0m MNCResizeKnobView.m
+[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPDFExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInspectorViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInspectorClipView.m
+[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+ObjectsConvenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNode+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNumberFormatter.m
+[33m▸[0m [39;1mAnalyzing[0m NSDateFormatter+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXMindNodeSingleFileExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme.m
+[33m▸[0m [39;1mAnalyzing[0m MNXKeyCommand.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument.m
+[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Components.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineBaseCellView.m
+[33m▸[0m [39;1mAnalyzing[0m NSView+LayoutConstraintFiltering.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRemindersSyncController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExtractCustomThemeWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFileLink.m
+[33m▸[0m [39;1mAnalyzing[0m NSWindow+FullScreen.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTextAlignmentValueTransformer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCHoverNodeState.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPastePersistentManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBranchRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+MNEscaping.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLayoutControllerManager.m
+[33m▸[0m [39;1mAnalyzing[0m NSIndexPath+MNCollectionView.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+UUID.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNDefaults.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+Stack.m
+[33m▸[0m [39;1mAnalyzing[0m MNCShapeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeView.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableArray+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXClipView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCColorValueTransformer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxy.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTranslateNodeController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineRowView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXShortcutsPreferencesViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnection+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTranslateNodeKnobState.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocument.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadDocumentViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOpenBrowserSharingService.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColorWell+Bindings.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelectionController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXShadowSeparatorContentView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMarkdownExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNoteIndicatorButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedControl.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNote.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportToOmniFocusViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverManager.m
+[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXFontManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserItem.m
+[33m▸[0m [39;1mAnalyzing[0m NSPopover+MNDetach.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImageExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocument+Scripting.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPathView.m
+[33m▸[0m [39;1mAnalyzing[0m NSImage+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineLayouter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSettingsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSheetWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColorWell.m
+[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedControl.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+CIELAB.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPageSliderCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController+box2dInterface.m
+[33m▸[0m [39;1mAnalyzing[0m MNCContent.m
+[33m▸[0m [39;1mAnalyzing[0m NSView+Alignment.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXFontSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleValue.m
+[33m▸[0m [39;1mAnalyzing[0m MNTextView+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCText+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m NSSegmentedControl+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m NSFontDescriptor+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFontStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerComposedDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NSUserDefaults+MNCProperties.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAsset.m
+[33m▸[0m [39;1mAnalyzing[0m MNFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDevice.m
+[33m▸[0m [39;1mAnalyzing[0m MNMainThreadHangDetector.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeInteractionState.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPathStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNVector.m
+[33m▸[0m [39;1mAnalyzing[0m MNXVibrantButtonCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNXAppDelegate.m
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/macOS/Sources/App Flow/MNXAppDelegate.m:77:64: [33mUser-facing text should use localized string macro[0m
+
+node.title = [[MNCText alloc] initWithAttributedString:[[NSAttributedString alloc] initWithString:@"Test"]];
+[36m                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+
+
+[33m▸[0m [39;1mAnalyzing[0m MNXDraggingOperationState.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeRepresentedObject.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCHandoffDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMigrationManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXLayoutManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeEditAccountWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXQuickLookController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCConvexHullController.m
+[33m▸[0m [39;1mAnalyzing[0m NSTextAttachment+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCSVParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCIThoughtsParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTranslateCrossConnectionKnobState.m
+[33m▸[0m [39;1mAnalyzing[0m NSURL+QueryParsing.m
+[33m▸[0m [39;1mAnalyzing[0m MNCFreeMindExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXAboutWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m NSView+Insertion.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPlainTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXStyleInspectorViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXGeneralPreferencesViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineDefines.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRichTextExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCLinkUserIntentDispatcher.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSidebarContainer.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMindjetParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBaseDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NSParagraphStyle+MNConvenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSwitch.m
+[33m▸[0m [39;1mAnalyzing[0m MNXContentInspectorViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOPMLExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCUserGuideView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImageAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m MNCArrowStyle.m
+[33m▸[0m [39;1mAnalyzing[0m NSData+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPrintAccessoryViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSingleAxisScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTaskSyncController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCValueTransformerRegistration.m
+[33m▸[0m [39;1mAnalyzing[0m MNCExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXAttachableButtonCell.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineTasksDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCNodeUserIntentDispatcher.m
+[33m▸[0m [39;1mAnalyzing[0m NSApplication+LaunchServices.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme+Creation.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImageView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCloudShapeGenerator.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineSearchDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m MNCText.m
+[33m▸[0m [39;1mAnalyzing[0m NSEvent+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTask.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeAccessoryButton.m
+[33m▸[0m [39;1mAnalyzing[0m NSCursor+ObjectManipulationCursors.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInspectorSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOPMLParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineNodeCache.m
+[33m▸[0m [39;1mAnalyzing[0m NSMutableAttributedString+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m NSPasteboard+Additions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeBorderSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCanvasInteractionState.m
+[33m▸[0m [39;1mAnalyzing[0m NSBezierPath+MNCGPathRef.m
+[33m▸[0m [39;1mAnalyzing[0m CAAnimation+MNCompletionBlocks.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPreferencesView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXFoldingIndicatorButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNXThingsAppleScriptExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvas+MNPropertyRepresentation.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNoteSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInfoTextViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPathStyleSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAttachmentRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m NSValue+MNPlatformCompatibility.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImagePickerViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColorSwatchView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCImagePickerContentDataSource.m
+[33m▸[0m [39;1mAnalyzing[0m NSSharingService+MNXAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSanitizingTextView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBranchRepresentedObject.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSubselectionResizeKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNImporting.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCanvasView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAnalyticsTracker.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeUploadCompleteViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColorGridView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarContainerView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDemoOverlayView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportToThingsViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXMyMindNodePreferencesViewController.m
+[33m▸[0m [39;1mAnalyzing[0m NSString+Paths.m
+[33m▸[0m [39;1mAnalyzing[0m MNError.m
+[33m▸[0m [39;1mAnalyzing[0m MNCLayoutManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTheme1To2MigrationController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCanvasUserIntentDispatcher.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument4to5MigrationController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvas.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportSheetToolbarButtonContainerView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocument+MNExporting.m
+[33m▸[0m [39;1mAnalyzing[0m MNXFreemindExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXRubberBandView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImageExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineTableView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCanvasPrintView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasRenderer.m
+[33m▸[0m [39;1mAnalyzing[0m MNXPDFExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportToRemindersSharingService.m
+[33m▸[0m [39;1mAnalyzing[0m MNCAshtonValueTransformer.m
+[33m▸[0m [39;1mAnalyzing[0m MNXMindMapSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeShareLinkViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTextExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCRemindersExporter.m
+[33m▸[0m [39;1mAnalyzing[0m NSScrollView+ScrollingAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTaskButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArtAttachment.m
+[33m▸[0m [39;1mAnalyzing[0m NSURL+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTextOutlineParser.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTextFinderClient.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOPMLExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStrokeStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodePopoverViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArt.m
+[33m▸[0m [39;1mAnalyzing[0m NSFont+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNXLeadingSidebarTabController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMyMindNodeDocument.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNZooming.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCollisionController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCClipArtSet.m
+[33m▸[0m [39;1mAnalyzing[0m MNCNodeWellButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNXFunctions.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineCellView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeShapeSectionViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCSVExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNCBaseStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNXOutlineSearchCellView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeShareWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTaskButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPersistentObjectSavingManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXVibrantSquareSegmentedCell.m
+[33m▸[0m [39;1mAnalyzing[0m NSView+Animation.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+NodeActions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCrossConnectionStyle.m
+[33m▸[0m [39;1mAnalyzing[0m MNXScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionCanvasViewController+MNCCrossConnectionUserIntentDispatcher.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCreateNodeInteractionState.m
+[33m▸[0m [39;1mAnalyzing[0m MNMyMindNodeRegisterWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXAttachedTextField.m
+[33m▸[0m [39;1mAnalyzing[0m MNXExportViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCTextController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXSearchField.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPersistentImageManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXInteractionState.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDemoLaunchWindowController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserCell.m
+[33m▸[0m [39;1mAnalyzing[0m SSWZip.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasSelection.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNViewActions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCDocumentKVOController+Selection.m
+[33m▸[0m [39;1mAnalyzing[0m NSObject+MNSwizzling.m
+[33m▸[0m [39;1mAnalyzing[0m MNXCreateCrossConnectionState.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTrailingSidebarTabController.m
+[33m▸[0m [39;1mAnalyzing[0m NSAttributedString+Convenience.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSimpleXMLExporter.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDragAndDropImageView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCMindNodeExporter.m
+[33m▸[0m [39;1mAnalyzing[0m NSGraphicsContext+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCPasteboardController.m
+[33m▸[0m [39;1mAnalyzing[0m MNXResizableScrollView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXColoredSegmentedCell.m
+[33m▸[0m [39;1mAnalyzing[0m NSObject+MNCoalescing.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTextView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXImageBrowserView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCachingImageManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXNodeWellButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNColor+MNAdditions.m
+[33m▸[0m [39;1mAnalyzing[0m MNCUndoManager.m
+[33m▸[0m [39;1mAnalyzing[0m MNXTextEditor.m
+[33m▸[0m [39;1mAnalyzing[0m MTDXMLElement.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchToggleButton.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCycleNode.m
+[33m▸[0m [39;1mAnalyzing[0m MNXDocumentWindowController+MNCDocumentUserIntentDispatcher.m
+[33m▸[0m [39;1mAnalyzing[0m main.m
+[33m▸[0m [39;1mAnalyzing[0m MNCCanvasViewController.m
+[33m▸[0m [39;1mAnalyzing[0m MNCOutlineBranchColorView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXView.m
+[33m▸[0m [39;1mAnalyzing[0m MNCResizeKnobView.m
+[33m▸[0m [39;1mAnalyzing[0m MNXMarkdownExportViewController.m
+[33m▸[0m [39;1mLinking[0m MindNode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Printing.mindnodetheme
+[33m▸[0m [39;1mCopying[0m ThemeMindMap.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Teal.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Coffee.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/thawte.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/WelcomeScreen/MNWelcomeAnimation.mp4
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Greyscale.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Pods/Target\ Support\ Files/Pods-MindNode\ for\ macOS/Pods-MindNode\ for\ macOS-acknowledgements.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startComCertAuthG2.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Tropical.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Fresh.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/MindNode.sdef
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Delight.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Candyland.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Elegant.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Vintage.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Blackboard.mindnodetheme
+[33m▸[0m [39;1mCopying[0m Resources/Colors
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Classic.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical\ Tinted.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m Resources/Acknowledgements.rtf
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/startssl.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/isrgrootx1.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Certificates/geotrust.cer
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Themes/Ocean.mindnodetheme
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Resources/Stickers/Tropical.mindnodeclipart
+[33m▸[0m [39;1mCopying[0m Pods-MindNode\ for\ macOS-metadata.plist
+[33m▸[0m [39;1mCompiling[0m MNXOutlineViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeRegisterWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXShortcutsPreferencesViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXExportSheetViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadCompleteViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXInteractionCanvasViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXOutlineSettingsViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXNoteSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXTextExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXNodeShapeSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXInfoTextViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXExportToThingsViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXExportToOmniFocusViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXThemeCollectionViewItem.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXNodeBorderSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXThemeViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeEditAccountWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXFreemindExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXContentInspectorViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXMindMapSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXMindNodeSingleFileExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXExportToRemindersViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXFontSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXPreferencesWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXMyMindNodePreferencesViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXLeadingSidebarTabController.xib
+[33m▸[0m [39;1mCompiling[0m MNXPathStyleSectionViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXPDFExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeShareLinkViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXAboutWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXOPMLExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXPrintOutlineTableView.xib
+[33m▸[0m [39;1mCompiling[0m MNXNodePopoverViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXGeneralPreferencesViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXDocumentWindowToolbarController.xib
+[33m▸[0m [39;1mCompiling[0m MNXExtractCustomThemeWindowController.xib
+[33m▸[0m [39;1mCompiling[0m MNXStyleInspectorViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXTrailingSidebarTabController.xib
+[33m▸[0m [39;1mCompiling[0m MNXMarkdownExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXImagePickerViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXImageExportViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNXPrintAccessoryViewController.xib
+[33m▸[0m [39;1mCompiling[0m MNMyMindNodeUploadDocumentViewController.xib
+[33m▸[0m [39;1mCompiling[0m MainMenu.xib
+[33m▸[0m [39;1mProcessing[0m MindNodeMac-Info.plist
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNodeQuickLookPlugIn.qlgenerator
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNodeSpotlightImporter.mdimporter
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Reachability.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Shared.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Ashton.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/AppReceiptValidator.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/ZIPFoundation.framework
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Helper.app
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mAnalyzing[0m MindNode for macOS/MindNode for macOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCBoundaryMorphTests.swift:52:56: [33m'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value[0m
+
+let polygons = stride(from: 0, to: 500, by: 1).flatMap { _ in self.makePolygon(in: rect) }
+[36m                                                       ^[0m
+
+
+[33m▸[0m [39;1mCompiling[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mCompiling[0m MNTextTests.m
+[33m▸[0m [39;1mCompiling[0m NSDictionary+MNTestHelper.m
+[33m▸[0m [39;1mCompiling[0m SSWZipTests.m
+[33m▸[0m [39;1mCompiling[0m MNCStyleProxyTests.m
+[33m▸[0m [39;1mAnalyzing[0m MNCSpotlightIndexer.m
+[33m▸[0m [39;1mAnalyzing[0m MNTextTests.m
+[33m▸[0m [39;1mAnalyzing[0m NSDictionary+MNTestHelper.m
+[33m▸[0m [39;1mAnalyzing[0m SSWZipTests.m
+[33m▸[0m [39;1mAnalyzing[0m MNCStyleProxyTests.m
+[33m▸[0m [39;1mLinking[0m MindNode\
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/FreeMind.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/ExportNewDocument.applescript
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Norwegian\ Sample\ Mind\ Map.mm
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ touch\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedEncryptedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedDataDescriptorArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedLZMAArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 3.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderWithoutCentralDirectoryArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TextBundleRoundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Security\ Scoped\ Bookmark.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ with\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MNCText\ Import.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Layout\ Tests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedMSDOSArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks_V5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildSameName.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV6.mindnode
+[33m▸[0m [39;1mCopying[0m WatchModel.plist
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 2.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Organise\ and\ Publish.textbundle
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV4.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/TaskPaperExportDocument.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SpotlightTestV5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Import.csv
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Style.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Test.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExport.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/WatchExport.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingTaskStateRightAligned().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv4.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindJet\ Exported.mmap
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ Tasks.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 5.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/exampleDoc.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CSV\ Export.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/XMindMap.xmind
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedCorruptFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyMainNodeWithLayoutStyleManual().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 6.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iPhone\ Settings.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/LayoutChange.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Unsupported\ Document\ Version.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/BigMindMapForPerformanceTests.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/RewireNodeTest.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Empty\ Document.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/CrossConnectionPerformance.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/SingleChildDifferentNames.opml
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWCompressedFolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.rtf
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Cleaning\ a\ bike\ without\ images.markdown
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Packliste.txt
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Ordered\ Mind\ Map.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/taskPaperExportForOmniFocus.taskpaper
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Roundtrip.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTestv3.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Mind\ Map\ Controller\ Documents/Mind\ Map\ Controller_testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault().mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/iThoughtsImportTest.itmz
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 1.mindnode
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Vendor/SSWZip/SSWZip/SSWZipTests/SSWUncompressedZIP64FolderArchive.zip
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/Markdown\ Exported.md
+[33m▸[0m [39;1mCopying[0m /usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Test\ Documents/MindNode\ Document\ Version\ 4.mindnode
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'
+[33m▸[0m [39;1mTouching[0m MindNode\ for\ macOS\ Tests.xctest
+
+The following commands produced analyzer issues:
+Analyze Sources/App\ Flow/MNXAppDelegate.m normal x86_64
+(1 command with analyzer issues)
+[33m▸[0m [39;1mAnalyze[0m Succeeded
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeSpotlightImporter [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Helper [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Quick Entry [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+
+[33m⚠️  [0m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Purchasing/Purchasing/Service/PurchaseService.swift:542:9: [33mIdentifier Name Violation: Variable name should be between 3 and 40 characters long: 'upgradePathFromAdditionalDiscountedProduct' (identifier_name)[0m
+
+Linting 'XCTestCase+ObservableAssertions.swift' (371/601)
+[36m                                                       ^~~~~~~[0m
+
+
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mBuild[0m Succeeded
+2018-04-04 15:01:36.188 xcodebuild[366:518559]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-E9023235-F910-4796-AFA3-4EAB72A88C81/MindNode for macOS Tests-C8D6BDF2-984C-47E3-A5E9-A58016A976BA/Session-MindNode for macOS Tests-2018-04-04_150136-iWKEid.log
+2018-04-04 15:01:36.189 xcodebuild[366:512580] [MT] IDETestOperationsObserverDebug: (86B4D351-31CC-427E-AE88-2D1931D5121E) Beginning test session MindNode for macOS Tests-86B4D351-31CC-427E-AE88-2D1931D5121E at 2018-04-04 15:01:36.189 with Xcode 9E145 on target <DVTLocalComputer: 0x7fdf7a304520 (My Mac | x86_64)> (10.13.4 (17E199))
+2018-04-04 15:01:36.193 xcodebuild[366:518559]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/var/folders/fp/wh9f3l6n5zx9_dfnzfr3xnzw0000gn/T/com.apple.dt.XCTest/IDETestRunSession-E9023235-F910-4796-AFA3-4EAB72A88C81/Purchasing Tests macOS-ACC9AD36-EF2E-4990-87DE-0B7861FF4581/Session-Purchasing Tests macOS-2018-04-04_150136-KtxOCk.log
+2018-04-04 15:01:36.193 xcodebuild[366:512580] [MT] IDETestOperationsObserverDebug: (1F5DF392-C3B1-4A80-A4B4-2C7FC415B0E4) Beginning test session Purchasing Tests macOS-1F5DF392-C3B1-4A80-A4B4-2C7FC415B0E4 at 2018-04-04 15:01:36.193 with Xcode 9E145 on target <DVTLocalComputer: 0x7fdf7a304520 (My Mac | x86_64)> (10.13.4 (17E199))
+[33m▸[0m [39;1mBuilding[0m Purchasing/CommonCrypto macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/CHCSVParser-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/MNCLogging-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/cmark-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m ZIPFoundation/ZIPFoundation [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m AppReceiptValidator/AppReceiptValidator macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Swiftlint'
+[33m▸[0m [39;1mBuilding[0m Ashton/Ashton [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/box2d-macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Shared/Shared macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Reachability/ReachabilityMac [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeQuickLookPlugIn [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNodeSpotlightImporter [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Helper [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode Quick Entry [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mBuilding[0m Pods/Pods-MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Demo macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mCompiling[0m ViewController.swift
+[33m▸[0m [39;1mCompiling[0m AppDelegate.swift
+[33m▸[0m [39;1mLinking[0m Purchasing\
+[33m▸[0m [39;1mCompiling[0m Main.storyboard
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/CommonCrypto.framework
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/Purchasing.framework
+[33m▸[0m [39;1mTouching[0m Purchasing\ Demo\ macOS.app
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m 'Preflight Script'
+[33m▸[0m [39;1mRunning script[0m 'Postflight Script'
+[33m▸[0m [39;1mRunning script[0m 'Highlight TODOs'
+[33m▸[0m [39;1mCopying[0m /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Build/Products/Debug/MindNode\ Quick\ Entry.app
+[33m▸[0m [39;1mTouching[0m MindNode.app
+[33m▸[0m [39;1mBuilding[0m Purchasing/Purchasing Tests macOS [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mProcessing[0m Info.plist
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework
+[33m▸[0m [39;1mCopying[0m /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework
+[33m▸[0m [39;1mCompiling[0m VersionNumberTests.swift
+[33m▸[0m [39;1mCompiling[0m ReceiptAssets.swift
+[33m▸[0m [39;1mCompiling[0m MockPurchasingServiceConfiguration.swift
+[33m▸[0m [39;1mCompiling[0m XCTestCase+ObservableAssertions.swift
+[33m▸[0m [39;1mCompiling[0m PromotedVisibilityUpdaterTests.swift
+[33m▸[0m [39;1mCompiling[0m TestAssetLoading.swift
+[33m▸[0m [39;1mCompiling[0m LicenseAssets.swift
+[33m▸[0m [39;1mCompiling[0m License+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m LicenseValidatorTests.swift
+[33m▸[0m [39;1mCompiling[0m SignatureVerifierTests.swift
+[33m▸[0m [39;1mCompiling[0m CurrentReceiptValidationTests.swift
+[33m▸[0m [39;1mCompiling[0m UpgradePathAnalysisTests.swift
+[33m▸[0m [39;1mCompiling[0m MockDefaults.swift
+[33m▸[0m [39;1mCompiling[0m Date+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+Convenience.swift
+[33m▸[0m [39;1mCompiling[0m DataStoreTestContext.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceTestContext.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceDataStoreTests.swift
+[33m▸[0m [39;1mCompiling[0m PurchaseServiceTests.swift
+[33m▸[0m [39;1mCompiling[0m MockStorePromotionControllerWrapper.swift
+[33m▸[0m [39;1mCompiling[0m Receipt+DemoData.swift
+[33m▸[0m [39;1mCompiling[0m MockStoreKitWrapper.swift
+[33m▸[0m [39;1mLinking[0m Purchasing\
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/wildcard.alamofire.org.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.2.3.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-root-ca.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity01
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/expired.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-dns-name.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial_and_full.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity02
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_trial.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/missing-dns-name-and-uri.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01.txt
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_3394.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithoutTrial_SignedWithProduction.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity02_rsaCert.der
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/valid-uri.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial_and_fullversion.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_michaelsandbox_receipt1.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_original_147.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicenseWithTrial_With_Identity01.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02_Signature_With_Identity02
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData01_Signature_With_Identity01
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsSignedLicense_With_Identity01.json
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/MindNodeLicensingProduction_rsaCert.der
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_vpp.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca2.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_legacy_original_2.5.7.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_current_original_fullversionfree.b64
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca1.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/test.alamofire.org.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_ios_legacy_vpp.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/PlainData02.txt
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/multiple-dns-names.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/alamofire-signing-ca1.cer
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Receipts/mindnode_mac_current_trial.b64
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsLicenseWithTrial_SignedWithProduction.json
+[33m▸[0m [39;1mCopying[0m Purchasing\ Tests\ Shared/Test\ Assets/Signature\ Assets/Alamo/signed-by-ca2.cer
+[33m▸[0m [39;1mCopying[0m License\ Assets/Test/UnitTestsIdentity01_rsaCert.der
+[33m▸[0m [39;1mTouching[0m Purchasing\ Tests\ macOS.xctest
+[33m▸[0m [39;1mBuilding[0m MindNode for macOS/MindNode for macOS Tests [Debug]
+[33m▸[0m [39;1mCheck Dependencies[0m
+[33m▸[0m [39;1mRunning script[0m '[CP] Check Pods Manifest.lock'
+[33m▸[0m [39;1mRunning script[0m '[CP] Copy Pods Resources'
+[33m▸[0m [39;1mRunning script[0m '[CP] Embed Pods Frameworks'
+[33m▸[0m [39;1mRunning script[0m 'Add extended attribute for Scoped Bookmark Test'
+[39;1mAll tests[0m
+Test Suite [39;1mMindNode for macOS Tests.xctest[0m started
+[39;1mMNCCSVExporterTests[0m
+[32;1m✓[0m testCounterOfLevels ([31m0.360[0m seconds)
+[32;1m✓[0m testCSV (0.023 seconds)
+[32;1m✓[0m testCSVisNotEmpty (0.022 seconds)
+[32;1m✓[0m testHeader (0.022 seconds)
+[39;1mMNCCSVImporterTests[0m
+[32;1m✓[0m testImport (0.019 seconds)
+[32;1m✓[0m testMainNodes (0.017 seconds)
+[32;1m✓[0m testStructure (0.016 seconds)
+[32;1m✓[0m testTotalNodes (0.016 seconds)
+[39;1mMNCCanvasControllerTests[0m
+[32;1m✓[0m testCanvasControllerSetup (0.022 seconds)
+[32;1m✓[0m testInsertParentNode ([33m0.054[0m seconds)
+[32;1m✓[0m testRemoveAllNodes ([33m0.027[0m seconds)
+[32;1m✓[0m testRemoveNode ([33m0.028[0m seconds)
+[32;1m✓[0m testRemoveNodeAndSubnodes (0.023 seconds)
+[32;1m✓[0m testRepresentedObject ([33m0.027[0m seconds)
+[39;1mMNCCanvasSelectionControllerTests[0m
+[32;1m✓[0m testCanvasSelectionConvenienceGetters (0.004 seconds)
+[32;1m✓[0m testCanvasSelectionEqualsSelectionController (0.003 seconds)
+[32;1m✓[0m testCanvasSelectionGetsResetAfterSelectionChange (0.003 seconds)
+[39;1mMNCCanvasTests[0m
+[32;1m✓[0m testAddNode (0.001 seconds)
+[32;1m✓[0m testRemoveAllNodes (0.001 seconds)
+[39;1mMNCCollisionControllerTests[0m
+[32;1m✓[0m testBoundsCollision ([33m0.061[0m seconds)
+[32;1m✓[0m testMindMapControllerSelectionMovement ([33m0.087[0m seconds)
+[32;1m✓[0m testRectHitTest ([33m0.042[0m seconds)
+[39;1mMNCDocument4to5MigrationControllerTests[0m
+[32;1m✓[0m testMigration (0.018 seconds)
+[32;1m✓[0m testTextMigration (0.021 seconds)
+[39;1mMNCDocument5to6MigrationControllerTests[0m
+[32;1m✓[0m testMigration ([33m0.030[0m seconds)
+[39;1mMNCDocumentKVOControllerTests[0m
+[32;1m✓[0m testNearestMindMapObject ([33m0.041[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleDefault ([33m0.031[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyLeftAlignedSubnodeWithLayoutStyleLeft ([33m0.030[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleDefault ([33m0.030[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleLeft ([33m0.029[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleManual ([33m0.030[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyMainNodeWithLayoutStyleRight ([33m0.029[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleDefault ([33m0.030[0m seconds)
+[32;1m✓[0m testSortingAlphabeticallyRightAlignedSubnodeWithLayoutStyleRight ([33m0.030[0m seconds)
+[32;1m✓[0m testSortingTaskStateRightAligned (0.023 seconds)
+[39;1mMNCDocumentOpenPerformanceTests[0m
+[33m◷[0m testLargeMindMapWithTasks measured ([31m1.024[0m seconds)
+[32;1m✓[0m testLargeMindMapWithTasks ([31m10.599[0m seconds)
+[33m◷[0m testMindMapWithLotsOfCrossConnections measured ([31m1.656[0m seconds)
+[32;1m✓[0m testMindMapWithLotsOfCrossConnections ([31m16.999[0m seconds)
+[33m◷[0m testMindMapWithLotsOfNodes measured ([31m3.170[0m seconds)
+[32;1m✓[0m testMindMapWithLotsOfNodes ([31m32.272[0m seconds)
+[39;1mMNCDocumentTests[0m
+[32;1m✓[0m testOpenDocumentWithUnsupportedVersionNumbers (0.017 seconds)
+[32;1m✓[0m testOpenDocumentWithVersion1 ([33m0.027[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion2 ([33m0.030[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion3 ([33m0.030[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion4 ([33m0.036[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion5 ([33m0.033[0m seconds)
+[32;1m✓[0m testOpenDocumentWithVersion6 ([33m0.042[0m seconds)
+[32;1m✓[0m testOpeningEmptyDocument (0.016 seconds)
+[32;1m✓[0m testOpenMindNodeTouchDocument (0.011 seconds)
+[32;1m✓[0m testResolvingSecurityScopedBookmark ([33m0.033[0m seconds)
+[39;1mMNCDocumentVersionDecisionTests[0m
+[32;1m✓[0m testExport (0.001 seconds)
+[32;1m✓[0m testNewDocument (0.001 seconds)
+[32;1m✓[0m testOpenDocument (0.001 seconds)
+[39;1mMNCFontExtractorTests[0m
+[32;1m✓[0m testCompoundEmoji (0.002 seconds)
+[32;1m✓[0m testEmoji (0.001 seconds)
+[32;1m✓[0m testEmptyString (0.001 seconds)
+[32;1m✓[0m testFontStyle (0.001 seconds)
+[32;1m✓[0m testFullyEmojiString (0.001 seconds)
+[32;1m✓[0m testFullySymbolic (0.001 seconds)
+[32;1m✓[0m testFullySymbolicAndEmojiString (0.001 seconds)
+[32;1m✓[0m testNormalFont (0.001 seconds)
+[32;1m✓[0m testSymbol (0.001 seconds)
+[32;1m✓[0m testSymbolAndEmoji (0.001 seconds)
+[32;1m✓[0m testSymbolWithWrongFont (0.002 seconds)
+[39;1mMNCFontManagerTests[0m
+[32;1m✓[0m testRandomGeneratedFontConversion1 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion10 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion100 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion11 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion12 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion13 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion14 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion15 (0.016 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion16 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion17 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion18 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion19 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion2 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion20 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion21 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion22 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion23 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion24 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion25 (0.010 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion26 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion27 (0.010 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion28 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion29 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion3 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion30 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion31 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion32 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion33 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion34 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion35 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion36 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion37 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion38 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion39 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion4 (0.012 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion40 (0.007 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion41 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion42 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion43 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion44 (0.010 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion45 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion46 (0.010 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion47 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion48 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion49 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion5 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion50 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion51 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion52 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion53 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion54 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion55 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion56 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion57 (0.014 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion58 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion59 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion6 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion60 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion61 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion62 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion63 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion64 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion65 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion66 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion67 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion68 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion69 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion7 (0.006 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion70 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion71 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion72 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion73 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion74 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion75 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion76 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion77 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion78 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion79 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion8 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion80 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion81 (0.012 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion82 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion83 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion84 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion85 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion86 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion87 (0.005 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion88 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion89 (0.003 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion9 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion90 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion91 (0.002 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion92 (0.004 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion93 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion94 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion95 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion96 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion97 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion98 (0.001 seconds)
+[32;1m✓[0m testRandomGeneratedFontConversion99 (0.002 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily1 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily2 (0.002 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily3 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily4 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily5 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForDifferentFontFamily6 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily1 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily10 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily11 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily12 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily13 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily14 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily2 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily3 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily4 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily5 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily6 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily7 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily8 (0.001 seconds)
+[32;1m✓[0m testThatFontManagerBehavesLikeNSFontManagerForSameFontFamily9 (0.001 seconds)
+[39;1mMNCFontStyleTests[0m
+[32;1m✓[0m testAttributedStringInit (0.001 seconds)
+[32;1m✓[0m testNilInit (0.001 seconds)
+[32;1m✓[0m testNodeRewire ([33m0.054[0m seconds)
+[32;1m✓[0m testNormalInit (0.001 seconds)
+[32;1m✓[0m testSymbolCharacter (0.001 seconds)
+[39;1mMNCFreeMindImporterTests[0m
+[32;1m✓[0m testBranchWidth ([31m2.016[0m seconds)
+[32;1m✓[0m testBubbleShape ([33m0.087[0m seconds)
+[32;1m✓[0m testCustomTitleColor ([33m0.084[0m seconds)
+[32;1m✓[0m testImport ([33m0.085[0m seconds)
+[32;1m✓[0m testLinks ([33m0.084[0m seconds)
+[32;1m✓[0m testMainNodeHasPillShape ([33m0.083[0m seconds)
+[32;1m✓[0m testNodeAlignment ([33m0.088[0m seconds)
+[32;1m✓[0m testNodeAttributedTitle ([33m0.083[0m seconds)
+[32;1m✓[0m testNodeTitle ([33m0.084[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.083[0m seconds)
+[32;1m✓[0m testParsesBranchColor ([33m0.085[0m seconds)
+[32;1m✓[0m testShapeFillColor ([33m0.085[0m seconds)
+[32;1m✓[0m testSpecialCharactersDecoding (0.014 seconds)
+[32;1m✓[0m testThatCrossConnectionsAreConnectingCorrectNodes ([33m0.083[0m seconds)
+[32;1m✓[0m testThatCrossConnectionsAreImported ([33m0.086[0m seconds)
+[32;1m✓[0m testThatCrossConnectionsHaveCorrectColor ([33m0.085[0m seconds)
+[32;1m✓[0m testThatFoldingIsRespected ([33m0.084[0m seconds)
+[32;1m✓[0m testThatFontNamesAreParsed ([33m0.085[0m seconds)
+[32;1m✓[0m testThatFontSizesAreParsed ([33m0.084[0m seconds)
+[32;1m✓[0m testThatNodesDeriveBubbleStyleFromParent ([33m0.084[0m seconds)
+[32;1m✓[0m testThatNodesDerivedBubbleStyleCanOverrideFillColor ([33m0.084[0m seconds)
+[32;1m✓[0m testThatNodesDerivedBubbleStyleDoesntHaveDerivedFillColor ([33m0.087[0m seconds)
+[32;1m✓[0m testThatNotesAreImported ([31m0.167[0m seconds)
+[32;1m✓[0m testThatParsesForkStyle ([33m0.084[0m seconds)
+[39;1mMNCFunctionsTests[0m
+[32;1m✓[0m testCGFloatEquality (0.001 seconds)
+[32;1m✓[0m testStringByRemovingCharactersInSet (0.001 seconds)
+[39;1mMNCHelloPayloadBuilderTests[0m
+[32;1m✓[0m testPayloadConstruction (0.002 seconds)
+[39;1mMNCImageExporterTests[0m
+[32;1m✓[0m testImageRepresentation ([31m2.907[0m seconds)
+[32;1m✓[0m testImageRepresentationWithoutBackground ([31m3.358[0m seconds)
+[32;1m✓[0m testImageRepresentationWithPadding ([31m2.637[0m seconds)
+[32;1m✓[0m testImageRepresentationWithScaling ([31m10.326[0m seconds)
+[39;1mMNCInsertPositionCalculatorTests[0m
+[32;1m✓[0m testInsertionOfSiblingsAboveAndBelow (0.003 seconds)
+[32;1m✓[0m testInsertPositionForManualLeftRightLayout (0.003 seconds)
+[32;1m✓[0m testInsertPositionForTopDownLayout (0.003 seconds)
+[39;1mMNCLayoutCalculatorTests[0m
+[32;1m✓[0m testHorizontalLayout (0.004 seconds)
+[33m◷[0m testHorizontalLayoutCalculationPerformance measured (0.015 seconds)
+[32;1m✓[0m testHorizontalLayoutCalculationPerformance ([31m1.442[0m seconds)
+[32;1m✓[0m testLayoutForLargeSupernodes (0.002 seconds)
+[32;1m✓[0m testVerticalLayout (0.004 seconds)
+[33m◷[0m testVerticalLayoutCalculationPerformance measured (0.015 seconds)
+[32;1m✓[0m testVerticalLayoutCalculationPerformance ([31m1.417[0m seconds)
+[39;1mMNCLayoutControllerTests[0m
+[32;1m✓[0m testDefaultLayoutControllerDeterminism (0.023 seconds)
+[32;1m✓[0m testLayoutStyleChange0 ([33m0.091[0m seconds)
+[32;1m✓[0m testLayoutStyleChange1 ([31m0.120[0m seconds)
+[32;1m✓[0m testLayoutStyleChange2 ([33m0.078[0m seconds)
+[32;1m✓[0m testLayoutStyleChange3 ([33m0.078[0m seconds)
+[32;1m✓[0m testLayoutStyleChange4 ([33m0.080[0m seconds)
+[32;1m✓[0m testLayoutStyleChange5 ([31m0.101[0m seconds)
+[32;1m✓[0m testThatLeftRightComputesTheSameAsReference ([33m0.092[0m seconds)
+[39;1mMNCMarkdownImporterTests[0m
+[32;1m✓[0m testContent ([33m0.037[0m seconds)
+[32;1m✓[0m testExportImportRoundTrip ([33m0.048[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.036[0m seconds)
+[32;1m✓[0m testStructure ([33m0.036[0m seconds)
+[32;1m✓[0m testTodos ([33m0.036[0m seconds)
+[39;1mMNCMindJetImporterTests[0m
+[32;1m✓[0m testCrossConnections ([31m0.119[0m seconds)
+[32;1m✓[0m testExportedBackgroundColor ([31m0.227[0m seconds)
+[32;1m✓[0m testExportedNodeTextFormatting ([31m0.222[0m seconds)
+[32;1m✓[0m testHyperlinks ([33m0.092[0m seconds)
+[32;1m✓[0m testImages ([31m0.353[0m seconds)
+[32;1m✓[0m testImport ([33m0.091[0m seconds)
+[32;1m✓[0m testNodeAlignment ([33m0.094[0m seconds)
+[32;1m✓[0m testNodeFormatting ([33m0.092[0m seconds)
+[32;1m✓[0m testNodeText ([33m0.092[0m seconds)
+[32;1m✓[0m testNodeTextFormatting ([33m0.092[0m seconds)
+[32;1m✓[0m testNotes ([33m0.092[0m seconds)
+[32;1m✓[0m testNotesAndHyperlinkOnSameNode ([33m0.091[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.092[0m seconds)
+[32;1m✓[0m testTaskStatus ([31m0.223[0m seconds)
+[39;1mMNCMindMapTests[0m
+[32;1m✓[0m testImportWithInvalidLayoutStyle (0.001 seconds)
+[39;1mMNCMyMindNodeTokenStoreTests[0m
+[32;1m✓[0m testMyMindNodeKeyRetrieval (0.001 seconds)
+[32;1m✓[0m testTokenStoring (0.001 seconds)
+[39;1mMNCNodeControllerTests[0m
+[32;1m✓[0m testParsingOfNodeDataFromTitle (0.003 seconds)
+[39;1mMNCNodeHierarchyTests[0m
+[32;1m✓[0m testEmptyNodeHierarchy (0.001 seconds)
+[32;1m✓[0m testManualNodeHierarchy (0.003 seconds)
+[32;1m✓[0m testNodeHierarchyOfOpenedDocument ([33m0.090[0m seconds)
+[32;1m✓[0m testNodeRewire ([31m0.109[0m seconds)
+[32;1m✓[0m testNodeRewireWith2MindMaps ([33m0.077[0m seconds)
+[39;1mMNCNodeLayoutCalculatorTests[0m
+[32;1m✓[0m testNodeLayoutCalculation (0.002 seconds)
+[39;1mMNCOPMLImporterTests[0m
+[32;1m✓[0m testNumberOfNodes ([33m0.028[0m seconds)
+[32;1m✓[0m testSpecialSingleChildCase (0.015 seconds)
+[32;1m✓[0m testStructure ([33m0.027[0m seconds)
+[32;1m✓[0m testTasks ([33m0.028[0m seconds)
+[39;1mMNCPasteboardTests[0m
+[32;1m✓[0m testCanvasObjectPasteboardParserRoundTrip ([31m0.147[0m seconds)
+[32;1m✓[0m testEmptyPasteboard (0.013 seconds)
+[32;1m✓[0m testPasteboardCanvasObject (0.004 seconds)
+[32;1m✓[0m testPasteboardController ([31m0.149[0m seconds)
+[32;1m✓[0m testPasteboardCrossConnectionStyle (0.003 seconds)
+[32;1m✓[0m testPasteboardEmptyString (0.001 seconds)
+[32;1m✓[0m testPasteboardFontStyle (0.002 seconds)
+[32;1m✓[0m testPasteboardImage ([33m0.084[0m seconds)
+[32;1m✓[0m testPasteboardNodeStyle (0.002 seconds)
+[32;1m✓[0m testPasteboardString (0.006 seconds)
+[39;1mMNCPropertyRepresentationTests[0m
+[32;1m✓[0m testV6PropertyRepresentation ([33m0.038[0m seconds)
+[39;1mMNCSetSynchronizerTests[0m
+[32;1m✓[0m testInitialSyncMerging (0.001 seconds)
+[32;1m✓[0m testOurAddition (0.001 seconds)
+[32;1m✓[0m testOurAdditionTheirAddition (0.001 seconds)
+[32;1m✓[0m testOurAdditionTheirRemoval (0.001 seconds)
+[32;1m✓[0m testOurRemoval (0.001 seconds)
+[32;1m✓[0m testOurRemovalTheirAddition (0.001 seconds)
+[32;1m✓[0m testOurRemovalTheirRemoval (0.001 seconds)
+[32;1m✓[0m testSyncFailureRollback (0.001 seconds)
+[32;1m✓[0m testThatInvalidStateExceptionIsThrown (0.001 seconds)
+[32;1m✓[0m testTheirAddition (0.001 seconds)
+[32;1m✓[0m testTheirRemoval (0.001 seconds)
+[39;1mMNCSpotlightImporterTests[0m
+[32;1m✓[0m testSpotlightIndexerForUnsupportedDocumentVersion (0.003 seconds)
+[32;1m✓[0m testV4SpotlightIndexerForValidDocument (0.003 seconds)
+[32;1m✓[0m testV5SpotlightIndexerForBigDocument ([33m0.069[0m seconds)
+[32;1m✓[0m testV5SpotlightIndexerForEmptyDocument (0.002 seconds)
+[32;1m✓[0m testV5SpotlightIndexerForValidDocument (0.005 seconds)
+[32;1m✓[0m testV5SpotlightIndexerWithCrossConnectionTitle (0.003 seconds)
+[32;1m✓[0m testV5SpotlightIndexerWithNotes (0.002 seconds)
+[32;1m✓[0m testV6SpotlightIndexer (0.003 seconds)
+[39;1mMNCStyleDocument1to2MigrationTests[0m
+[32;1m✓[0m testThatStyleDocumentUpgradeAndDowngradeResultsInOriginalStyleDocument (0.006 seconds)
+[39;1mMNCStyleProxyTests[0m
+[32;1m✓[0m testBoxing (0.016 seconds)
+[32;1m✓[0m testKeyPathAccess (0.013 seconds)
+[32;1m✓[0m testStyleProxyObjectUpdate (0.014 seconds)
+[32;1m✓[0m testTextManipulation ([33m0.039[0m seconds)
+[32;1m✓[0m testTextSpecialCase (0.020 seconds)
+[32;1m✓[0m testThatRemovingLastObjectResultsInEmptyStyleProxy (0.012 seconds)
+[32;1m✓[0m testThatRemovingOfValuesResultsInCorrectStyleValue (0.014 seconds)
+[32;1m✓[0m testValueTransformer (0.015 seconds)
+[39;1mMNCTaskControllerTest[0m
+[33m◷[0m testActivatingDeactivatingTaskStatePerformance measured ([31m0.597[0m seconds)
+[32;1m✓[0m testActivatingDeactivatingTaskStatePerformance ([31m7.358[0m seconds)
+[32;1m✓[0m testMultipleTaskSettingOnDeepTree (0.003 seconds)
+[32;1m✓[0m testProgressCalculationOnDeepTree (0.003 seconds)
+[32;1m✓[0m testProgressCalculationOnFlatTree (0.002 seconds)
+[32;1m✓[0m testRefreshOfStatesOnDeepTree (0.003 seconds)
+[32;1m✓[0m testRefreshOfStatesOnFlatTree (0.002 seconds)
+[33m◷[0m testRefreshPerformance measured (0.025 seconds)
+[32;1m✓[0m testRefreshPerformance ([31m1.572[0m seconds)
+[32;1m✓[0m testShowTaskControlOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTaskCreationViaTitle (0.004 seconds)
+[32;1m✓[0m testTaskPropagationOnDeepTree (0.002 seconds)
+[32;1m✓[0m testTaskPropagationOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTogglingNodeStatesOnFlatTree (0.002 seconds)
+[32;1m✓[0m testTogglingOfCompletionStateOnDeepTree (0.003 seconds)
+[32;1m✓[0m testTogglingOfTaskStatesOnDeepTree (0.003 seconds)
+[33m◷[0m testTogglingTaskStatePerformance measured ([31m0.256[0m seconds)
+[32;1m✓[0m testTogglingTaskStatePerformance ([31m3.901[0m seconds)
+[32;1m✓[0m testUndoTaskToggleOnDeepTree (0.004 seconds)
+[39;1mMNCTaskPaperExporterTests[0m
+[32;1m✓[0m testTaskPaperExport ([33m0.040[0m seconds)
+[32;1m✓[0m testTaskPaperExportWithOmniFocusConfiguration ([33m0.041[0m seconds)
+[39;1mMNCTaskPaperImporterTests[0m
+[32;1m✓[0m testInlineTags ([33m0.031[0m seconds)
+[32;1m✓[0m testNotes ([33m0.030[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.030[0m seconds)
+[32;1m✓[0m testStructure ([33m0.031[0m seconds)
+[32;1m✓[0m testTasks ([33m0.030[0m seconds)
+[39;1mMNCTextBundleExporterTests[0m
+[32;1m✓[0m testBundleContent ([33m0.068[0m seconds)
+[39;1mMNCTextBundleImporterTests[0m
+[32;1m✓[0m testExportImportRoundTrip ([31m0.559[0m seconds)
+[32;1m✓[0m testImportOfTextBundleFile ([31m0.145[0m seconds)
+[39;1mMNCTextExporterTests[0m
+[32;1m✓[0m testNodeOrderOfPlainTextExport ([33m0.089[0m seconds)
+[39;1mMNCTextOutlineImporterTests[0m
+[31m✗[0m testPasteboard, failed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x6040032466c0> was mutated while being enumerated."
+[32;1m✓[0m testPlainTextImport ([31m0.351[0m seconds)
+[32;1m✓[0m testRichTextImport ([31m0.317[0m seconds)
+[39;1mMNCTheme2to3MigrationTests[0m
+[32;1m✓[0m testPartialNodeStyleWithColor (0.007 seconds)
+[32;1m✓[0m testPartialNodeStyleWithNode (0.007 seconds)
+[32;1m✓[0m testThatThemeUpgradeAndDowngradeResultsInOriginalTheme (0.009 seconds)
+[39;1mMNCThemeDataSourceTests[0m
+[32;1m✓[0m testThemeOrder (0.001 seconds)
+[39;1mMNCThemeManagerTests[0m
+[32;1m✓[0m testAddTheme (0.012 seconds)
+[32;1m✓[0m testRemoveTheme (0.011 seconds)
+[32;1m✓[0m testStandardThemes (0.001 seconds)
+[39;1mMNCThemeTests[0m
+[32;1m✓[0m testThemePreviewImageGeneration ([31m0.378[0m seconds)
+[39;1mMNCThingsExporterTests[0m
+[32;1m✓[0m testExportURLGenertion ([33m0.062[0m seconds)
+[32;1m✓[0m testJSONDataExport ([33m0.057[0m seconds)
+[39;1mMNCXMindImporterTests[0m
+[32;1m✓[0m testBackgroundColor ([33m0.082[0m seconds)
+[32;1m✓[0m testContent ([33m0.046[0m seconds)
+[32;1m✓[0m testCrossConnections ([33m0.051[0m seconds)
+[32;1m✓[0m testLinks ([33m0.054[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([33m0.047[0m seconds)
+[32;1m✓[0m testStructure ([33m0.056[0m seconds)
+[39;1mMNCXMindStyleImporterTest[0m
+[32;1m✓[0m testBorder ([31m0.239[0m seconds)
+[32;1m✓[0m testBorderLineWidth ([31m0.198[0m seconds)
+[32;1m✓[0m testColor ([31m0.198[0m seconds)
+[32;1m✓[0m testCrossConnectionStyle ([31m0.200[0m seconds)
+[39;1mMNCZoomingCalculatorTests[0m
+[32;1m✓[0m testCalculatorZoomIn (0.001 seconds)
+[32;1m✓[0m testCalculatorZoomOut (0.001 seconds)
+[32;1m✓[0m testCalculatorZoomScaleEqual (0.001 seconds)
+[32;1m✓[0m testDifferentInsets (0.001 seconds)
+[39;1mMNCiThoughtsImporterTests[0m
+[32;1m✓[0m testBoundariesV4 ([33m0.099[0m seconds)
+[32;1m✓[0m testCrossConnections ([31m0.415[0m seconds)
+[32;1m✓[0m testCrossConnectionsV3 ([33m0.080[0m seconds)
+[32;1m✓[0m testCrossConnectionsV4 ([33m0.098[0m seconds)
+[32;1m✓[0m testHyperlinks ([31m0.418[0m seconds)
+[32;1m✓[0m testHyperlinksV3 ([33m0.077[0m seconds)
+[32;1m✓[0m testHyperlinksV4 ([33m0.099[0m seconds)
+[32;1m✓[0m testImages ([31m0.677[0m seconds)
+[32;1m✓[0m testImport ([31m0.400[0m seconds)
+[32;1m✓[0m testImportV3 ([33m0.077[0m seconds)
+[32;1m✓[0m testImportV4 ([33m0.095[0m seconds)
+[32;1m✓[0m testLayoutStyle ([31m0.407[0m seconds)
+[32;1m✓[0m testLayoutStyleV3 ([31m0.406[0m seconds)
+[32;1m✓[0m testLineTypeV4 ([33m0.096[0m seconds)
+[32;1m✓[0m testNodeAlignment ([31m0.406[0m seconds)
+[32;1m✓[0m testNodeAlignmentV3 ([33m0.078[0m seconds)
+[32;1m✓[0m testNodeAlignmentV4 ([33m0.097[0m seconds)
+[32;1m✓[0m testNodeFormatting ([31m0.405[0m seconds)
+[32;1m✓[0m testNodeFormattingV3 ([33m0.079[0m seconds)
+[32;1m✓[0m testNodeFormattingV4 ([33m0.096[0m seconds)
+[32;1m✓[0m testNodeText ([31m0.413[0m seconds)
+[32;1m✓[0m testNodeTextFormatting ([31m0.404[0m seconds)
+[32;1m✓[0m testNodeTextV3 ([33m0.079[0m seconds)
+[32;1m✓[0m testNodeTextV4 ([33m0.098[0m seconds)
+[32;1m✓[0m testNotes ([31m0.410[0m seconds)
+[32;1m✓[0m testNumberOfNodes ([31m0.406[0m seconds)
+[32;1m✓[0m testNumberOfNodesV3 ([33m0.077[0m seconds)
+[32;1m✓[0m testNumberOfNodesV4 ([33m0.096[0m seconds)
+[32;1m✓[0m testTasks ([31m0.415[0m seconds)
+[39;1mMNColorTests[0m
+[32;1m✓[0m testBlackWhiteComplementColor (0.001 seconds)
+[32;1m✓[0m testColorComponentRetrieval (0.001 seconds)
+[32;1m✓[0m testDarkenedColor (0.001 seconds)
+[32;1m✓[0m testDerivedColor (0.001 seconds)
+[32;1m✓[0m testLightenedColor (0.001 seconds)
+[32;1m✓[0m testPropertyRepInit (0.001 seconds)
+[32;1m✓[0m testRGBComplementColor (0.001 seconds)
+[32;1m✓[0m testWebColorString3Init (0.001 seconds)
+[32;1m✓[0m testWebColorString6Init (0.001 seconds)
+[32;1m✓[0m testWebColorString8Init (0.001 seconds)
+[39;1mMNTextTests[0m
+[32;1m✓[0m testApplyStyle ([33m0.027[0m seconds)
+[32;1m✓[0m testApplyStyleInRange (0.004 seconds)
+[32;1m✓[0m testEditing (0.001 seconds)
+[32;1m✓[0m testEmptyInit (0.001 seconds)
+[32;1m✓[0m testFindString (0.001 seconds)
+[32;1m✓[0m testInit (0.002 seconds)
+[32;1m✓[0m testSavingAndLoadingOfStringWithSpecialControlCharacters (0.002 seconds)
+[32;1m✓[0m testSetString (0.002 seconds)
+[32;1m✓[0m testTextWithAttributes (0.001 seconds)
+[32;1m✓[0m testTextWithFont ([33m0.074[0m seconds)
+[32;1m✓[0m testTextWithFontMonospaced ([33m0.057[0m seconds)
+[39;1mMNXBetaControllerTests[0m
+[32;1m✓[0m testBetaInformationEncryption (0.002 seconds)
+[39;1mMNXOpenURLRouteTests[0m
+[32;1m✓[0m testBetaActivationRoute (0.001 seconds)
+[32;1m✓[0m testPurchaseRoute (0.001 seconds)
+[39;1mMNXScriptingTests[0m
+[32;1m✓[0m testExportNewDocumentAsCSV ([31m0.929[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsDocX ([31m0.520[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsFreeMind ([31m0.306[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsMarkdown ([31m0.443[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsMSFF ([31m0.450[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsOPML ([31m0.572[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsPDF ([31m0.316[0m seconds)
+[32;1m✓[0m testExportNewDocumentAsPNG ([31m0.459[0m seconds)
+[39;1mMorphingTests[0m
+[32;1m✓[0m testNormalization (0.001 seconds)
+[33m◷[0m testPerformance measured ([31m0.206[0m seconds)
+[32;1m✓[0m testPerformance ([31m2.651[0m seconds)
+[32;1m✓[0m testSimpleInsert (0.001 seconds)
+[32;1m✓[0m testSimpleMatch (0.001 seconds)
+[32;1m✓[0m testSimpleMorph (0.001 seconds)
+[39;1mNSAttributedStringMarkdownTests[0m
+[32;1m✓[0m testBoldItalic (0.002 seconds)
+[32;1m✓[0m testBoldMarkdownConversion (0.001 seconds)
+[32;1m✓[0m testCombiningAttributes (0.001 seconds)
+[32;1m✓[0m testItalicMarkdownConversion (0.001 seconds)
+[32;1m✓[0m testLinkConversion (0.001 seconds)
+[32;1m✓[0m testParagraphs (0.001 seconds)
+[32;1m✓[0m testPlainTextConversion (0.001 seconds)
+[32;1m✓[0m testStrikethroughConversion (0.001 seconds)
+[39;1mNSRangeSwiftTests[0m
+[32;1m✓[0m testFullRange (0.001 seconds)
+[32;1m✓[0m testSubStringFromIndex (0.001 seconds)
+[32;1m✓[0m testSubStringFromRange (0.001 seconds)
+[39;1mSSWZipTests[0m
+[32;1m✓[0m testAddCompressedEntry (0.024 seconds)
+[32;1m✓[0m testAddSymbolicLink (0.009 seconds)
+[32;1m✓[0m testAddUncompressedEntry (0.020 seconds)
+[32;1m✓[0m testCreateCompressedArchive (0.007 seconds)
+[32;1m✓[0m testCreateNestedDirectoryStrucutre (0.009 seconds)
+[32;1m✓[0m testCreateUncompressedArchive (0.007 seconds)
+[32;1m✓[0m testDetectionOfUnspportedFormatFeatures ([33m0.028[0m seconds)
+[32;1m✓[0m testLastModFileDate (0.009 seconds)
+[32;1m✓[0m testLastModFileTime (0.009 seconds)
+[32;1m✓[0m testNonUnixOSTypes (0.008 seconds)
+[32;1m✓[0m testPosixPermissions (0.010 seconds)
+[32;1m✓[0m testRemoveCompressedEntry ([33m0.050[0m seconds)
+[32;1m✓[0m testRemoveUncompressedEntry ([33m0.040[0m seconds)
+[32;1m✓[0m testUnzipCompressedEntryToData ([33m0.056[0m seconds)
+[32;1m✓[0m testUnzipCompressedEntryToURL ([33m0.035[0m seconds)
+[32;1m✓[0m testUnzipCompressedFolderArchive (0.006 seconds)
+[33m◷[0m testUnzipCompressedFolderEntries measured (0.003 seconds)
+[32;1m✓[0m testUnzipCompressedFolderEntries ([31m0.332[0m seconds)
+[32;1m✓[0m testUnzipItemAtURL ([33m0.042[0m seconds)
+[32;1m✓[0m testUnzipItemAtURLErrorConditions (0.006 seconds)
+[32;1m✓[0m testUnzipUncompressedEntryToData (0.013 seconds)
+[32;1m✓[0m testUnzipUncompressedEntryToURL (0.014 seconds)
+[32;1m✓[0m testUnzipUncompressedFolderArchive (0.006 seconds)
+[32;1m✓[0m testUnzipUncompressedFolderEntries (0.019 seconds)
+[33m◷[0m testZipDirectoryContentsAtURL measured ([33m0.074[0m seconds)
+[32;1m✓[0m testZipDirectoryContentsAtURL ([31m1.005[0m seconds)
+[32;1m✓[0m testZipDirectoryContentsAtURLErrorConditions (0.006 seconds)
+
+
+MindNode_for_macOS_Tests.MNCTextOutlineImporterTests
+testPasteboard, [31mfailed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x6040032466c0> was mutated while being enumerated."[0m
+[36m/usr/local/var/buildkite-agent/builds/ci01.local-1/ideasoncanvas/mindnode/Core/Tests/Sources/MNCTextOutlineImporterTests.swift:36[0m
+```
+[38;5;230m            [39m[38;5;221;01mlet[39;00m[38;5;230m [39m[38;5;153;01mmainNode[39;00m[38;5;230m [39m[38;5;87m=[39m[38;5;230m [39m[38;5;230mdocument[39m[38;5;87m.[39m[38;5;230mcanvas[39m[38;5;87m.[39m[38;5;230mmindMaps[39m[38;5;87m[[39m[38;5;212;01m0[39;00m[38;5;87m][39m[38;5;87m.[39m[38;5;230mmainNode[39m[38;5;230m
+[38;5;230m            [39m[38;5;230mdocumentController[39m[38;5;87m.[39m[38;5;230mcanvasController[39m[38;5;87m.[39m[38;5;153mrewireNodes[39m[38;5;87m([39m[38;5;230mmainNode[39m[38;5;87m.[39m[38;5;230msubnodes[39m[38;5;230m [39m[38;5;221;01mas[39;00m[38;5;230m [39m[38;5;155;01mNSArray[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mto[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mnil[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mwantNewLocation[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mtrue[39;00m[38;5;87m,[39m[38;5;230m [39m[38;5;153;01mcanInheritStyle[39;00m[38;5;87m:[39m[38;5;230m [39m[38;5;212;01mfalse[39;00m[38;5;87m)[39m[38;5;230m
+[38;5;230m            [39m[38;5;230mdocumentController[39m[38;5;87m.[39m[38;5;230mcanvasController[39m[38;5;87m.[39m[38;5;153mremoveNodeAndAllSubnodes[39m[38;5;87m([39m[38;5;230mmainNode[39m[38;5;87m)[39m[38;5;230m
+[38;5;230m[39m  ```
+
+
+[31m	 Executed 462 tests, with 1 failure (1 unexpected) in 124.772 (125.029) seconds
+[0m
+[39;1mSelected tests[0m
+Test Suite [39;1mPurchasing Tests macOS.xctest[0m started
+[39;1mCurrentReceiptParsingTests[0m
+[32;1m✓[0m testiOSReceiptValidation ([31m0.307[0m seconds)
+[32;1m✓[0m testMacOSReceiptValidation (0.006 seconds)
+[39;1mLicenseValidatorTests[0m
+[32;1m✓[0m testBrokenLicenseData (0.006 seconds)
+[32;1m✓[0m testBrokenSignedLicenseData (0.001 seconds)
+[32;1m✓[0m testEmtpyData (0.001 seconds)
+[32;1m✓[0m testMissingData (0.001 seconds)
+[32;1m✓[0m testParsingSignedLicense1 (0.001 seconds)
+[32;1m✓[0m testValidatingSignedLicense (0.010 seconds)
+[32;1m✓[0m testValidatingSignedLicenseWithTrial (0.003 seconds)
+[32;1m✓[0m testValidatingSignedProductionLicense (0.002 seconds)
+[32;1m✓[0m testValidatingSignedProductionLicenseWithTrial (0.003 seconds)
+[32;1m✓[0m testValidatingSkippingCertificate (0.002 seconds)
+[32;1m✓[0m testValidatingSkippingDeviceIdentifier (0.003 seconds)
+[32;1m✓[0m testWrongCertificate (0.006 seconds)
+[32;1m✓[0m testWrongDeviceIdentifier (0.008 seconds)
+[32;1m✓[0m testWrongDeviceIdentifierAndCertificate (0.002 seconds)
+[39;1mPromotedVisibilityUpdaterTests[0m
+[32;1m✓[0m testCatalogNeeded (0.002 seconds)
+[32;1m✓[0m testDoubleUpdateProtection (0.006 seconds)
+[32;1m✓[0m testInitialVisibilityUpdates (0.001 seconds)
+[32;1m✓[0m testOverriddenUpdating (0.002 seconds)
+[32;1m✓[0m testVisibiliesForFullVersion (0.001 seconds)
+[32;1m✓[0m testVisibiliesFromTrial (0.003 seconds)
+[32;1m✓[0m testVisibilitiesForPendingDecision (0.003 seconds)
+[39;1mPurchaseServiceDataStoreTests[0m
+[32;1m✓[0m testPersistence (0.002 seconds)
+[32;1m✓[0m testUpdateMethods (0.002 seconds)
+[39;1mPurchaseServiceTests[0m
+[32;1m✓[0m testActiveTrialLicenseTrumpsViewerOnly (0.011 seconds)
+[32;1m✓[0m testAdditionalAvailableDiscountedProductOverrulesReceipt (0.006 seconds)
+[32;1m✓[0m testFromExpiredIAPTrialToViewerOnly (0.008 seconds)
+[32;1m✓[0m testFromIAPTrialToViewerOnly (0.005 seconds)
+[32;1m✓[0m testFullPurchase (0.007 seconds)
+[32;1m✓[0m testFullPurchaseFromTrialLicense (0.007 seconds)
+[32;1m✓[0m testIAPTrialExpiry (0.019 seconds)
+[32;1m✓[0m testIAPTrialVsLongerTrialLicense (0.005 seconds)
+[32;1m✓[0m testIAPTrialVsShorterTrialLicense (0.005 seconds)
+[32;1m✓[0m testLicenseTrialExpiry (0.023 seconds)
+[32;1m✓[0m testPurchaseServiceInitializationWithExistingLicense (0.009 seconds)
+[32;1m✓[0m testPurchaseServiceInitializationWithoutExistingLicense (0.006 seconds)
+[32;1m✓[0m testPurchaseServiceInvalidReceiptData (0.005 seconds)
+[32;1m✓[0m testReceiptOverrulesAdditionalAvailableDiscountedProduct (0.005 seconds)
+[32;1m✓[0m testStartingTrial (0.007 seconds)
+[32;1m✓[0m testViewerOnlyThenTrialLicenseThenViewerOnly (0.009 seconds)
+[39;1mSignatureVerifierTests[0m
+[32;1m✓[0m testCorrectSignatures (0.004 seconds)
+[32;1m✓[0m testMalformedData (0.002 seconds)
+[32;1m✓[0m testMalformedSignatureData (0.001 seconds)
+[32;1m✓[0m testMlformedCertificateData (0.001 seconds)
+[33m◷[0m testPerformanceOfSignatureVerification measured (0.001 seconds)
+[32;1m✓[0m testPerformanceOfSignatureVerification ([31m0.306[0m seconds)
+[32;1m✓[0m testWrongSignatures (0.007 seconds)
+[39;1mUpgradePathAnalysisTests[0m
+[32;1m✓[0m testConcreteiOSUpgradePathAnalysis (0.008 seconds)
+[32;1m✓[0m testConcreteMacOSUpgradePathAnalysis (0.002 seconds)
+[32;1m✓[0m testiOSLegacyReceiptParsing (0.007 seconds)
+[32;1m✓[0m testMacOSLegacyReceiptParsing (0.004 seconds)
+[39;1mVersionNumberTests[0m
+[32;1m✓[0m testDigitsAndDotsComparison (0.001 seconds)
+[32;1m✓[0m testDigitsAndDotsParsing (0.001 seconds)
+[32;1m✓[0m testDigitsOnly (0.001 seconds)
+[32;1m✓[0m testDigitsOnlyParsing (0.001 seconds)
+
+
+[32;1m	 Executed 55 tests, with 0 failures (0 unexpected) in 0.869 (0.899) seconds
+[0m
+** TEST FAILED **
+[15:03:50]: [31mExit status: 65[0m
++--------------------+-----+
+|       Test Results       |
++--------------------+-----+
+| Number of tests    | 517 |
+| Number of failures | [31m1[0m   |
++--------------------+-----+
+
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                            [33mLane Context[0m                                                                                            |
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| PLATFORM_NAME              | mac                                                                                                                                                                   |
+| LANE_NAME                  | mac staticAnalyze                                                                                                                                                     |
+| SCAN_DERIVED_DATA_PATH     | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq                                                                        |
+| SCAN_GENERATED_PLIST_FILES | ["/Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Logs/Test/5A1E0505-4589-4FEC-AB7E-4454CC3F5DCE_TestSummaries.plist"] |
+| SCAN_GENERATED_PLIST_FILE  | /Users/administrator/Library/Developer/Xcode/DerivedData/MindNode-awupgnnswxhlvsdmpjmytakjyjaq/Logs/Test/5A1E0505-4589-4FEC-AB7E-4454CC3F5DCE_TestSummaries.plist     |
++----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+[15:03:50]: [31mTests have failed[0m
+
++------+----------------------------+-------------+
+|                [32mfastlane summary[0m                 |
++------+----------------------------+-------------+
+| Step | Action                     | Time (in s) |
++------+----------------------------+-------------+
+| 1    | Verifying fastlane version | 0           |
+| 2    | clear_derived_data         | 2           |
+| 💥   | [31mscan[0m                       | 346         |
++------+----------------------------+-------------+
+
+[15:03:50]: [31mfastlane finished with errors[0m
+[31m
+[!] Tests have failed[0m
+
+#######################################################################
+# fastlane 2.89.0 is available. You are on 2.79.0.
+# You should use the latest version.
+# Please update using `bundle update fastlane`.
+#######################################################################
+
+[32m2.89.0 Improvements[0m
+* [action] Make sure get_version_number targets respond to test_target_type? (#12212) via Josh Holtz
+* [action] Make enable_automatic_code_signing for all configurations (#12187) via Nicolas Braun
+* [produce]Use correct spelling of icloud service in product/service.rb (#12134) via Jakub Knejzlík
+* [action] Add Support for Registering Mac Devices on Apple Developer Portal (#11978) via Baumchen
+* [spaceship] Spaceship delete testflight groups (#12111) via Kenneth Wong
+* [produce] Enable set 'NFC Tag Reading' at 'fastlane produce' cli. (#12179) (#12201) via Kazuhide Takahashi
+* [frameit] frameit documentation describes all parameters from the Framefile (#11662) via funnel20
+* [supply] Clarify difference between SUPPLY_JSON_KEY and SUPPLY_JSON_KEY_DATA via Aaron Brager
+* [action] added custom api_url option to testfairy (#12153) via Josh Holtz
+
+[32m2.88.0 Improvements[0m
+* [action] Fix crashlytics to not autoload gsp_path if api_token is set (#12176) via Josh Holtz
+* Improve error message when specified scheme is not found (#12182) via Cédric Luthi
+* [action] Support checking remote git tags existence (#11675) via Takeru Chuganji
+* Use Android environment to find adb (don't just rely on it being in PATH) (#12168) via Adam Cohen-Rose
+* [snapshot] Make sure matched window has a non-empty frame (#12174) via François Pradel
+* [swift] Fixes string return value and shows all lanes (even without description) (#12171) via Josh Holtz
+* [scan] Default skip_build to true in Scanfile template (#12162) via Aaron Brager
+
+[32m2.87.0 Lots of action fixes and xcodeproj gem update[0m
+* [supply] Added internal track (#12128) via Josh Holtz
+* [Action] get_latest_version handles $(SRCROOT) and tries to get target that isn't test (#12138) via Josh Holtz
+* [Action] app_store_build_number converts return to int if possible (#12148) via Josh Holtz
+* Workspace contained schemes now get loaded (#12147) via Lou Franco
+* Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting iOS projects (#12142) via Hiroyuki Morita
+* [Action] Add use_bundle_exec option to pod_push action (#11947) via Nicolas Braun
+* [match] Write Match encrypted files in binary mode to avoid UndefinedConversion error (#12112) via Michael Smith
+* [Action] Fix a bug that upload_symbols_to_crashlytics fails if path has a space (#12098) via Takeru Chuganji
+
+[32mTo see all new releases, open https://github.com/fastlane/fastlane/releases[0m
+
+[32mPlease update using `bundle update fastlane`[0m
+15:03:53 [[0;32mMESSAGE[0;0m] Platform.swift [Line: 23]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+15:03:53 [[0;32mMESSAGE[0;0m] PurchaseService.swift [Line: 542]  Identifier Name Violation: Variable name should be between 3 and 40 characters long: 'upgradePathFromAdditionalDiscountedProduct' (identifier_name)
+15:03:53 [[0;32mMESSAGE[0;0m] Data+Serialization.swift [Line: 60]  'allocate(bytes:alignedTo:)' is deprecated: renamed to 'allocate(byteCount:alignment:)'
+15:03:53 [[0;32mMESSAGE[0;0m] MNXAppDelegate.m [Line: 77]  User-facing text should use localized string macro
+15:03:53 [[0;32mMESSAGE[0;0m] MNCBoundaryMorphTests.swift [Line: 52]  'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
+15:03:53 [[0;32mMESSAGE[0;0m] Reachability.swift [Line: 136]  plaform condition appears to be testing for simulator environment; use 'targetEnvironment(simulator)' instead
+15:03:53 [[0;32mMESSAGE[0;0m] ✗ testPasteboard
+15:03:53 [[0;33mWARNING[0;0m] Fastlane exit code: 65
+15:03:53 [[0;32mMESSAGE[0;0m] --------------------- Summary ---------------------
+15:03:53 [[0;32mMESSAGE[0;0m] Ignored Keywords: todo, -Wpragma, type-check (limit:
+15:03:53 [[0;31m ERROR [0;0m] 6. Static Analyzer Warnings
+15:03:53 [[0;31m ERROR [0;0m] 1. Unit Test Errors
+15:03:53 [[0;31m ERROR [0;0m] Static Analyzer failed


### PR DESCRIPTION
* remove staticAnalyzerMessages.count from exit number

becuase Xcode 9.3 prints warnings and static Analyser Issues in the same format do not pass them to exit function. The warnings are postet in Slack but do not block a merge in GitHub