### PR TITLE
Slack Support

### DIFF
--- a/Callisto.xcodeproj/project.pbxproj
+++ b/Callisto.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		CD9DF3A922FC2A1A00779F6F /* Check.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DF3A822FC2A1A00779F6F /* Check.swift */; };
 		CD9DF3AB22FC4AEF00779F6F /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DF3AA22FC4AEF00779F6F /* Comment.swift */; };
 		CDB22D312303F985002A1EF3 /* String+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB22D302303F985002A1EF3 /* String+Sugar.swift */; };
+		CDB5A97C251A722D00CC486F /* PostSlackAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB5A97B251A722D00CC486F /* PostSlackAction.swift */; };
 		CDF007082074FAC200257FCC /* mac_build_8731.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF007062074FAC200257FCC /* mac_build_8731.log */; };
 		CDF007092074FAC200257FCC /* ios_build_8731.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF007072074FAC200257FCC /* ios_build_8731.log */; };
 		CDF0070E20760B1900257FCC /* ios_build_8745.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF0070C20760B1900257FCC /* ios_build_8745.log */; };
@@ -131,6 +132,7 @@
 		CD9DF3A822FC2A1A00779F6F /* Check.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Check.swift; sourceTree = "<group>"; };
 		CD9DF3AA22FC4AEF00779F6F /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		CDB22D302303F985002A1EF3 /* String+Sugar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Sugar.swift"; sourceTree = "<group>"; };
+		CDB5A97B251A722D00CC486F /* PostSlackAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSlackAction.swift; sourceTree = "<group>"; };
 		CDF007062074FAC200257FCC /* mac_build_8731.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mac_build_8731.log; sourceTree = "<group>"; };
 		CDF007072074FAC200257FCC /* ios_build_8731.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_8731.log; sourceTree = "<group>"; };
 		CDF0070C20760B1900257FCC /* ios_build_8745.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_8745.log; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				CD8BBDDB1EE009C600E8EE2E /* main.swift */,
 				CD4E0F6722F43DC500C31E08 /* SummariseAction.swift */,
 				CD4E0F6D22F4475A00C31E08 /* UploadAction.swift */,
+				CDB5A97B251A722D00CC486F /* PostSlackAction.swift */,
 				CD33AF6E22F0766E002EC27C /* ExtractBuildInformationController.swift */,
 				CD8BBDFA1EE00A8E00E8EE2E /* Parser */,
 				CD8BBDF41EE00A2500E8EE2E /* Communication Controller */,
@@ -450,6 +453,7 @@
 			files = (
 				CD0E20D923040AFE001D9159 /* Result+Sugar.swift in Sources */,
 				CD9DF3A922FC2A1A00779F6F /* Check.swift in Sources */,
+				CDB5A97C251A722D00CC486F /* PostSlackAction.swift in Sources */,
 				CD9DF11722FC16D300779F6F /* CompilerMessage.swift in Sources */,
 				CD9DF11D22FC16D300779F6F /* Branch.swift in Sources */,
 				CD9DF12522FC16D300779F6F /* Common.swift in Sources */,

--- a/Callisto.xcodeproj/xcshareddata/xcschemes/CallistoTest.xcscheme
+++ b/Callisto.xcodeproj/xcshareddata/xcschemes/CallistoTest.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD8320FD1EE7DF640029DBE0"
+               BuildableName = "CallistoTest.xctest"
+               BlueprintName = "CallistoTest"
+               ReferencedContainer = "container:Callisto.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Callisto/Common.swift
+++ b/Callisto/Common.swift
@@ -41,7 +41,7 @@ extension ExitCodes: CustomStringConvertible {
         case .invalidFastlaneFile:
             return "invalid file. Usage -fastlane \"/path/to/file\""
         case .invalidBranch:
-            return "invalid Branch"
+            return "invalid Branch. Usage -branch \"branch\""
         case .invalidGithubUsername:
             return "invalid Github username. Usage: -githubUsername \"username\""
         case .invalidGithubCredentials:

--- a/Callisto/GitHubCommunicationController.swift
+++ b/Callisto/GitHubCommunicationController.swift
@@ -29,6 +29,20 @@ class GitHubCommunicationController {
         } ?? [:]
     }
 
+    func branch(named name: String) -> Result<Branch, Error> {
+        do {
+            let dict: [String: Any]
+            try dict = self.pullRequest(forBranch: name)
+            guard let branchPath = dict["html_url"] as? String, let title = dict["title"] as? String else { throw GithubError.pullRequestNoURL }
+
+            let prNumber = dict["number"] as? Int
+            return .success(Branch(title: title, name: name, url: URL(string: branchPath), number: prNumber))
+        } catch {
+            LogError("Something happend when collecting information about Pull Requests")
+            return .failure(error)
+        }
+    }
+
     func postComment(on branch: Branch, comment: Comment) -> Result<Void, Error> {
         guard let url = self.makeCommentURL(for: branch) else { return .failure(StatusCodeError.noPullRequestURL) }
 

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -1,0 +1,118 @@
+//
+//  PostSlackAction.swift
+//  Callisto
+//
+//  Created by Patrick Kladek on 22.09.20.
+//  Copyright © 2020 IdeasOnCanvas. All rights reserved.
+//
+
+import Foundation
+
+
+/// Responsible to post the parsed build information to Slack
+final class PostSlackAction: NSObject {
+
+    private lazy var ignore: [String] = {
+        return self.defaults.ignoredKeywords
+    }()
+
+    let defaults: UserDefaults
+    let slackController: SlackCommunicationController
+    let githubController: GitHubCommunicationController
+
+    // MARK: - Lifecycle
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+        self.slackController = SlackCommunicationController(url: defaults.slackURL)
+        self.githubController = GitHubCommunicationController(account: defaults.githubAccount,
+                                                              repository: defaults.githubRepository)
+    }
+
+    // MARK: - PostSlackAction
+
+    func run() -> Never {
+        let inputFiles = CommandLine.parameters(forKey: "files").map { URL(fileURLWithPath: $0) }
+        guard inputFiles.count > 0 else { quit(.invalidBuildInformationFile) }
+
+        let infos = inputFiles.map { BuildInformation.read(url: $0) }.compactMap { result -> BuildInformation? in
+            switch result {
+            case .success(let info):
+                return info
+            case .failure(let error):
+                LogError("\(error)")
+                return nil
+            }
+        }
+
+        if infos.allSatisfy({ $0.isEmpty }) {
+            LogMessage("No Build issues found")
+            quit(.success)
+        }
+
+        let branch = self.currentBranch()
+        let slackMessage = self.makeSlackMessage(for: branch, infos: infos)
+        guard let data = slackMessage.jsonDataRepresentation() else { quit(.jsonConversationFailed) }
+
+        self.slackController.post(data: data)
+        quit(.success)
+    }
+}
+
+// MARK: - Private
+
+private extension PostSlackAction {
+
+    func currentBranch() -> Branch {
+        switch self.githubController.branch(named: defaults.branch) {
+        case .success(let branch):
+            return branch
+        case .failure(let error):
+            LogError(error.localizedDescription)
+            quit(.reloadBranchFailed)
+        }
+    }
+
+    func makeSlackMessage(for branch: Branch, infos: [BuildInformation]) -> SlackMessage {
+        let message = SlackMessage()
+
+        // Overview
+        let overViewAttachment = SlackAttachment(type: .good)
+        overViewAttachment.title = branch.title
+        overViewAttachment.titleURL = branch.url
+        overViewAttachment.footer = "Ignored: \(self.ignore.joined(separator: ", "))"
+        message.add(attachment: overViewAttachment)
+
+        // Errors
+        let errorAttachments = SlackAttachment(type: .danger)
+        let errors = infos.flatMap { $0.errors }
+        for compilerMessage in errors {
+            if self.ignore.contains(where: { compilerMessage.description.contains($0)}) { continue }
+
+            errorAttachments.addField(SlackField(message: compilerMessage))
+        }
+        message.add(attachment: errorAttachments)
+
+        // Warnings
+        let warningAttachments = SlackAttachment(type: .warning)
+        let warnings = infos.flatMap{ $0.warnings }
+        for compilerMessage in warnings {
+            if self.ignore.contains(where: { compilerMessage.description.contains($0)}) { continue }
+
+            warningAttachments.addField(SlackField(message: compilerMessage))
+        }
+        message.add(attachment: warningAttachments)
+
+        // Unit Tests
+        let unitTestAttachments = SlackAttachment(type: .danger)
+        unitTestAttachments.colorHex = "blue"
+        let unitTests = infos.flatMap { $0.unitTests }
+        for compilerMessage in unitTests {
+            if self.ignore.contains(where: { compilerMessage.description.contains($0)}) { continue }
+
+            unitTestAttachments.addField(SlackField(message: compilerMessage))
+        }
+        message.add(attachment: unitTestAttachments)
+        return message
+    }
+}

--- a/Callisto/SlackField.swift
+++ b/Callisto/SlackField.swift
@@ -24,6 +24,10 @@ class SlackField {
         let title = "\(message.file) [Line: \(message.line)]"
         self.init(title: title, value: message.message)
     }
+
+    convenience init(message: UnitTestMessage) {
+        self.init(title: "\(message.method)", value: "\(message.assertType)\n\(message.explanation)")
+    }
 }
 
 extension SlackField: DictionaryConvertable {

--- a/Callisto/UploadAction.swift
+++ b/Callisto/UploadAction.swift
@@ -27,7 +27,7 @@ final class UploadAction: NSObject {
 
     func run() -> Never {
         let inputFiles = CommandLine.parameters(forKey: "files").map { URL(fileURLWithPath: $0) }
-        guard inputFiles.count > 0 else { quit(.invalidBuildInformationFile) }
+        guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
         let infos = self.filteredBuildInfos(inputFiles.map { BuildInformation.read(url: $0) }.compactMap { result -> BuildInformation? in
             switch result {

--- a/Callisto/UserDefaults+LaunchParameters.swift
+++ b/Callisto/UserDefaults+LaunchParameters.swift
@@ -15,6 +15,7 @@ extension UserDefaults {
         case help
         case summarise
         case upload
+        case slack
         case unknown
 
         static var possibleValues: String {
@@ -32,6 +33,8 @@ extension UserDefaults {
             return .summarise
         case "upload":
             return .upload
+        case "slack":
+            return .slack
         default:
             LogError("No action specified. Possible values are: \(Action.possibleValues)")
             exit(ExitCodes.invalidAction.rawValue)
@@ -62,7 +65,7 @@ extension UserDefaults {
     }
 
     var slackURL: URL {
-        let slackPath = self.string(forKey: "slack") ?? { quit(.invalidSlackWebhook) }()
+        let slackPath = self.string(forKey: "slackURL") ?? { quit(.invalidSlackWebhook) }()
         return URL(string: slackPath) ?? { quit(.invalidSlackWebhook) }()
     }
 
@@ -83,5 +86,22 @@ private extension Array {
         }
 
         return self[index]
+    }
+}
+
+extension CommandLine {
+
+    static func parameters(forKey key: String) -> [String] {
+        var inputFiles: [String] = []
+        for i in 0...CommandLine.arguments.count - 1 {
+            if CommandLine.arguments[i] == "-\(key)" {
+                for j in (i + 1)...(CommandLine.arguments.count - 1) {
+                    let argument = CommandLine.arguments[j]
+                    if argument.first == "-" { break }
+                    inputFiles.append(argument)
+                }
+            }
+        }
+        return inputFiles
     }
 }

--- a/Callisto/main.swift
+++ b/Callisto/main.swift
@@ -27,6 +27,10 @@ func main() {
         let action = UploadAction(defaults: defaults)
         action.run()
 
+    case .slack:
+        let action = PostSlackAction(defaults: defaults)
+        action.run()
+
     case .unknown:
         quit()
     }

--- a/README.md
+++ b/README.md
@@ -4,22 +4,80 @@
 ![alt text](https://img.shields.io/badge/Platform-Mac%2010.12+-blue.svg "Target Mac")
 
 
-![Logo](https://raw.githubusercontent.com/IdeasOnCanvas/Callisto/master/Documentation/Callisto%20Workflow%20Image.png "Logo")
+![Logo](https://raw.githubusercontent.com/IdeasOnCanvas/Callisto/main/Documentation/Callisto%20Workflow%20Image.png "Logo")
 
-Clang Static Analyzer is great, it catches lots of potential bugs and errors in your code. It has one downside though: running the Clang Static Analyzer every time you build your project takes a lot of time, and we all could use some shorter build times. Callisto solves this problem, as it allows you to run the Clang Static Analyzer on your build server (e.g. BuildKite) and posts the results to our favorite messaging tool Slack.
+Clang Static Analyzer is great, it catches lots of potential bugs and errors in your code. It has one downside though: running the Clang Static Analyzer every time you build your project takes a lot of time, and we all could use some shorter build times. Callisto solves this problem, as it allows you to run the Clang Static Analyzer on your build server (e.g. Buildkite) and posts the results to our favorite messaging tool Slack.
+
+### Installation
+
+Checkout the repo, open the project and build it. You can find the binary in the Products folder in Xcode. We recomend to checkin the binary in your project.
+
+### Usage
+
+Callisto runs in two steps. First it will sumarize the build log. In the second step it will post the results to Github and Slack.
+
+#### Summarize
+
+If you have multiple targets in your project run this step for each of them. For faster runs you can build each target on its own machine. With Buildkite it's possible to mark the created file as build artefact - this way it will be available on all buildservers (needed for the next step).
+
+```
+#!/bin/bash
+
+./Callisto summarise -fastlane '/tmp/fastlane_log.txt' -output .
+```
+
+To get the log from fastlane you can pipe its output through a file:
 
 ```
 #!/bin/bash
 
 fastlane ios static_analyze 2>&1 | tee /tmp/fastlane_iOS_Output.txt
-Callisto -fastlane "/tmp/fastlane_iOS_Output.txt" \
--slack "<SLACK_WEBHOOK_URL>" \
--branch "$BUILDKITE_BRANCH" \
--githubUsername "<GITHUB_USERNAME>" \
--githubToken "<GITHUB_TOKEN>" \
--githubOrganisation "<GITHUB_ORGANISATION>" \
--githubRepository "<GITHUB_REPOSITORY>" \
--ignore "todo, -Wpragma"
+```
+
+If you use Jenkins its a bit easier:
+
+```
+#!/bin/bash
+
+writeFile(file: "build-${env.BUILD_NUMBER}.txt", text: currentBuild.rawBuild.getLog(1000000).join('\n'), encoding: 'utf-8')
+
+```
+
+#### Comment on Github
+
+When all sumarize tasks finished you can post the build result to Github. 
+We recommend adding a new user to your github repo - we called it bot and created a personal access token for this account. Give it full access to `repo & users`. This token is then used by Callisto via a command line argument. Depending on your CI you can add this as a secret variable.
+
+We used some files which were included in multiple targets, therefore we got duplicated warnings & errors. To fix this Callisto is able to detect such cases and will correctly mark duplicated warnings & errors. Just make sure to add all .buildReport files.
+
+```
+#!/bin/bash
+
+./Callisto upload 
+	-githubToken $access_token 
+	-githubOrganisation $organisation 
+	-githubRepository $repo
+	-branch $branch_name
+	-deletePreviousComments YES
+	-ignore "todo, -Wpragma"
+	-files "./macTarget.buildReport ./iosTarget.buildReport"
+```
+
+#### Comment on Slack
+
+If would rather be notified about a failed build in slack use this command:
+
+```
+#!/bin/bash
+
+./Callisto slack 
+	-slackURL $slack_webhook
+	-githubToken $access_token
+	-githubOrganisation $organisation
+	-githubRepository $repo
+	-branch '${env.BRANCH_NAME}'
+	-ignore "todo, -Wpragma"
+	-files "./macTarget.buildReport ./iosTarget.buildReport"
 ```
 
 #### fastlane static_analyze lane:
@@ -45,12 +103,13 @@ end
 ### Parameters
 
 * `-slack`: create a Slack Webhook URL and pass it as a parameter to Callisto, to enable posting to Slack
-* `-branch`: when using BuildKite you can simply pass the environment variable "$BUILDKITE_BRANCH"
+* `-branch`: when using Buildkite you can simply pass the environment variable "$BUILDKITE_BRANCH"
 * `-githubUsername`: The username of a GitHub account that has access to your repository
 * `-githubToken`: The recommended way to safely connect to GitHub: create a token for your user
 * `-githubOrganisation`: needed to create the correct URL for communicating with GitHub
 * `-githubRepository`: needed to create the correct URL for communicating with GitHub
 * `-ignore`: pass keywords which should be excluded from your Slack report, e.g. you can exclude "todo"
+* `-deletePreviousComments` Used only for github. When set to `YES` only the lastest build summary is visible in your Pull Request.
 
 ### How does it work?
 


### PR DESCRIPTION
### Description

Right now I'm using Callisto in a workflow where the Pull Request is created when the task is finished. Therefore our approach with posting the build result to GitHub won't really work. Adding Slack support as it will be an improvement for such use cases.

### Tasks

- [x] Refactor duplicated code
- [x] Add `PostSlackAction` class
- [x] Implement -ignore parameter in `PostSlackAction` (When filtering in the summarize step we lose the keywords for slack)

### Infos for reviewer

The formatting of slack messages did change a bit. Now errors, warnings & unit tests are grouped together (and use the corresponding color). Unfortunately it uses the outdated format. Not sure if I have time to support the new Blocks API https://api.slack.com/tools/block-kit-builder

### Preview
![Bildschirmfoto 2020-09-22 um 22 56 02](https://user-images.githubusercontent.com/18739004/93936710-e1607100-fd26-11ea-9b92-2387dca2d710.png)


### Note should be merged after #8 